### PR TITLE
fix: prevent nav-menu overlap with right-side actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,12 +28,12 @@ body.lang-en .th-only { display: none !important; }
 .cursor-ring.hovering { width: 48px; height: 48px; border-color: #00FF41; transform: translate(-20px, -20px); }
 
 /* ─── NAV ─── */
-nav { position: fixed; top: 0; left: 0; right: 0; z-index: 1000; display: flex; justify-content: space-between; align-items: center; padding: 20px 40px; background: linear-gradient(180deg, #080806 60%, transparent); backdrop-filter: blur(4px); }
+nav { position: fixed; top: 0; left: 0; right: 0; z-index: 1000; display: grid; grid-template-columns: auto 1fr auto; align-items: center; gap: 16px; padding: 20px 40px; background: linear-gradient(180deg, #080806 60%, transparent); backdrop-filter: blur(4px); }
 .nav-logo { font-family: 'Space Mono', monospace; font-size: 14px; letter-spacing: 6px; color: #F7931A; text-decoration: none; display: flex; align-items: center; }
-.nav-menu { display: flex; gap: 24px; position: absolute; left: 50%; transform: translateX(-50%); }
-.nav-link { font-family: 'Space Mono', monospace; font-size: 10px; color: #666660; text-decoration: none; letter-spacing: 1px; transition: color 0.3s; }
+.nav-menu { display: flex; gap: 24px; justify-content: center; min-width: 0; flex-wrap: wrap; row-gap: 6px; }
+.nav-link { font-family: 'Space Mono', monospace; font-size: 10px; color: #666660; text-decoration: none; letter-spacing: 1px; transition: color 0.3s; white-space: nowrap; }
 .nav-link:hover { color: #F7931A; }
-.nav-right { display: flex; align-items: center; gap: 12px; }
+.nav-right { display: flex; align-items: center; gap: 12px; flex-shrink: 0; }
 .nav-auth-btn { font-family: 'Space Mono', monospace; font-size: 10px; letter-spacing: 2px; color: #00FF41; border: 1px solid rgba(0,255,65,0.3); padding: 6px 14px; background: transparent; cursor: none; transition: all 0.3s; }
 .nav-auth-btn:hover { color: #080806; background: #00FF41; border-color: #00FF41; }
 .lang-toggle { font-family: 'Space Mono', monospace; font-size: 12px; letter-spacing: 2px; color: #666660; border: 1px solid #666660; padding: 6px 14px; background: transparent; cursor: none; transition: all 0.3s; }
@@ -342,6 +342,11 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
 .reveal.visible { opacity: 1; transform: translateY(0); }
 
 /* ─── MOBILE ─── */
+@media (max-width: 1200px) {
+  nav { padding: 18px 24px; gap: 12px; }
+  .nav-menu { gap: 14px; }
+  .nav-link { font-size: 9px; letter-spacing: 0.5px; }
+}
 @media (max-width: 900px) {
   .nav-menu { display: none; }
 }


### PR DESCRIPTION
## Summary

Fixes the nav-menu overlap with the right-side action group (FORUM, DIALOGUE, LOGIN, EN/TH) that was visible on iPad-width viewports — see screenshot in the original report.

## Root cause

`.nav-menu` was positioned with `position: absolute; left: 50%; transform: translateX(-50%)`, which removed it from the `<nav>` flex layout entirely. As a result, the menu had **no awareness** of `.nav-right`, so when Thai labels stretched the menu wider than the viewport's center band, it overflowed and visually collided with the buttons on the right.

## Fix

Convert `<nav>` to a 3-column CSS grid (`auto 1fr auto`):

- `.nav-menu` is now a real grid item in the middle column. It still centers its children but is bounded by the logo on the left and the action group on the right.
- `.nav-right` gets `flex-shrink: 0` so its buttons keep full size when the menu is tight.
- `.nav-link` gets `white-space: nowrap` so multi-word Thai labels don't wrap mid-link.
- New `@media (max-width: 1200px)` breakpoint shrinks the menu gap and font size in the band between the existing `900px` (hide-menu) breakpoint and full desktop width — that's where the collision was worst.

## Diff size

+9 / −4 lines, all in `index.html`. No JS, no behavior changes.

## Test plan

- [ ] Open the live site at iPad portrait (~1024px) — confirm no overlap between the menu and the FORUM/DIALOGUE/LOGIN/EN-TH group
- [ ] Open at iPad landscape (~1366px) — same check
- [ ] Toggle EN ↔ TH — confirm the longer Thai labels still fit without overlap
- [ ] Open at narrow desktop (~1100px) — confirm shrunken menu still readable
- [ ] Open at <900px — confirm `.nav-menu` is hidden as before (no regression)
- [ ] Open at 375px (iPhone SE) — confirm no horizontal scroll