### PR TITLE
feat: convert Forum section to Mode B bilingual toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -312,6 +312,15 @@ nav { position: fixed; top: 0; left: 0; right: 0; z-index: 1000; display: flex; 
 .forum-attribution { text-align: center; margin-top: 48px; font-family: 'Space Mono', monospace; font-size: 9px; color: #666660; letter-spacing: 1px; }
 .forum-skeleton { max-width: 600px; margin: 40px auto; padding: 20px; background: rgba(0,255,65,0.03); border: 1px solid rgba(0,255,65,0.1); }
 .forum-skeleton-text { font-family: 'Space Mono', monospace; font-size: 11px; color: #00FF41; letter-spacing: 0.5px; }
+
+/* When EN-only mode is active, promote EN typography from secondary to primary
+   so it doesn't look like the dim subtext it shows next to the TH primary. */
+body.lang-en .forum-section-title-en { font-size: 32px; color: #d4d0c8; letter-spacing: 1px; margin-bottom: 24px; }
+body.lang-en .forum-subtitle-en { font-size: 15px; color: #d4d0c8; opacity: 1; line-height: 1.8; margin-bottom: 0; }
+body.lang-en .forum-card-title-en { font-size: 17px; color: #d4d0c8; opacity: 1; line-height: 1.5; margin-bottom: 16px; }
+body.lang-en .forum-card-summary-en { font-size: 12px; color: #d4d0c8; opacity: 0.95; line-height: 1.7; margin-bottom: 20px; }
+body.lang-en .forum-card-take-en { font-size: 12px; color: #d4d0c8; opacity: 0.95; line-height: 1.7; }
+
 @media (max-width: 980px) { .forum-grid { grid-template-columns: repeat(2, 1fr); } }
 @media (max-width: 640px) { .forum { padding: 80px 20px; } .forum-grid { grid-template-columns: 1fr; } .forum-card { padding: 28px 20px; } }
 
@@ -1446,20 +1455,23 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
 <section class="forum" id="forum">
   <div class="forum-eyebrow">BLOCK <span id="forumBlockHeight">---</span> · SOURCE: bitcointalk.org</div>
 
-  <div class="forum-section-title">ชุมชน — การตรวจสอบ</div>
-  <div class="forum-section-title-en">FORUM — COMMUNITY VERIFY</div>
+  <div class="forum-section-title th-only">ชุมชน — การตรวจสอบ</div>
+  <div class="forum-section-title-en en-only">FORUM — COMMUNITY VERIFY</div>
 
   <div class="forum-subtitle">
-    <div class="forum-subtitle-th">
+    <div class="forum-subtitle-th th-only">
       ทุกสัปดาห์เราคัดเลือก 21 กระทู้จากฟอรัมที่ Satoshi เคยโพสต์ — ผ่านมุมมองของหนังเรื่องนี้ เราไม่คัดลอกโพสต์ เราสรุปด้วยเสียงของเราเอง และลิงก์กลับไปที่ต้นฉบับ
     </div>
-    <div class="forum-subtitle-en">
+    <div class="forum-subtitle-en en-only">
       Each week we select 21 threads from the forum where Satoshi posted — through the lens of this film. We don't copy posts. We summarize in our own voice and link back to the source.
     </div>
   </div>
 
   <div class="forum-disclosure">
-    <div class="forum-disclosure-text">
+    <div class="forum-disclosure-text th-only">
+      คำชี้แจงทางบรรณาธิการ: เราสรุปและแปลความหัวข้อกระทู้ในแบบของเราเอง ไม่ได้คัดลอกโพสต์ต้นฉบับมา ทุกกระทู้ลิงก์กลับไปที่ต้นทางบน bitcointalk.org พร้อมชื่อผู้โพสต์ — และ "มุมของหนัง" สะท้อนว่าแต่ละกระทู้เชื่อมโยงกับธีมของเรื่องอย่างไร: หนี้ข้ามรุ่น, การตรวจสอบ, และอธิปไตยทางการเงิน
+    </div>
+    <div class="forum-disclosure-text en-only">
       EDITORIAL DISCLOSURE: We paraphrase thread titles and discussions. We do not reproduce original posts. Every thread links to its source on bitcointalk.org with the author's username. Our "take" reflects how each thread connects to the film's themes of generational debt, verification, and monetary sovereignty.
     </div>
   </div>
@@ -1477,7 +1489,8 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
   </div>
 
   <div class="forum-attribution">
-    All threads live on bitcointalk.org — the forum where Satoshi Nakamoto posted from 2009-2010.
+    <span class="th-only">ทุกกระทู้ยังคงอยู่บน bitcointalk.org — ฟอรัมที่ Satoshi Nakamoto โพสต์ระหว่างปี 2009-2010</span>
+    <span class="en-only">All threads live on bitcointalk.org — the forum where Satoshi Nakamoto posted from 2009-2010.</span>
   </div>
 </section>
 
@@ -2031,14 +2044,14 @@ document.querySelectorAll('a[href^="#"]').forEach(a => {
       return `
         <div class="forum-card reveal" id="forum-topic-${num}">
           <div class="forum-card-num">TOPIC ${num} / 21</div>
-          <div class="forum-card-title-th">${escapeHtml(topic.title_th || '')}</div>
-          <div class="forum-card-title-en">${escapeHtml(topic.title_en || '')}</div>
-          <div class="forum-card-summary-th">${escapeHtml(topic.summary_th || '')}</div>
-          <div class="forum-card-summary-en">${escapeHtml(topic.summary_en || '')}</div>
+          <div class="forum-card-title-th th-only">${escapeHtml(topic.title_th || '')}</div>
+          <div class="forum-card-title-en en-only">${escapeHtml(topic.title_en || '')}</div>
+          <div class="forum-card-summary-th th-only">${escapeHtml(topic.summary_th || '')}</div>
+          <div class="forum-card-summary-en en-only">${escapeHtml(topic.summary_en || '')}</div>
           <div class="forum-card-take">
-            <div class="forum-card-take-label">OUR TAKE · มุมของหนัง</div>
-            <div class="forum-card-take-th">${escapeHtml(topic.take_th || '')}</div>
-            <div class="forum-card-take-en">${escapeHtml(topic.take_en || '')}</div>
+            <div class="forum-card-take-label"><span class="th-only">มุมของหนัง</span><span class="en-only">OUR TAKE</span></div>
+            <div class="forum-card-take-th th-only">${escapeHtml(topic.take_th || '')}</div>
+            <div class="forum-card-take-en en-only">${escapeHtml(topic.take_en || '')}</div>
           </div>
           <div class="forum-card-footer">
             <div class="forum-card-author">${escapeHtml(topic.author || 'unknown')} · ${escapeHtml(topic.board || 'Bitcoin Discussion')}</div>


### PR DESCRIPTION
## Summary

The Forum section (`#forum`) was the only major area still hard-coding TH + EN side by side, regardless of the `.lang-th` / `.lang-en` body toggle used everywhere else on the site. This made the **EN/TH language switch in the nav feel half-broken** when scrolled to the forum — visible in the screenshot from the original report (Thai mode, but EN body text + EN-only "EDITORIAL DISCLOSURE" both showing).

This PR converts the entire forum section (header, body, disclosure, attribution, and per-card render) to **Mode B** — match the rest of the site.

> **Draft:** opened as Draft because this PR touches the `forumGrid` render function, which is on the "preserve existing features" list in `CLAUDE.md`. Owner review on mobile recommended before merge.

## What changed

### HTML (forum section header — `index.html:1446-1482`)

- `forum-section-title` → `.th-only`, `forum-section-title-en` → `.en-only`
- `forum-subtitle-th` / `forum-subtitle-en` → tagged with toggle classes
- **`forum-disclosure` previously had only EN.** Added a Thai paraphrase, both wrapped in toggle classes
- **`forum-attribution` previously had only EN.** Added a Thai version, both wrapped in toggle spans

### JS (`renderForumCards`, around `index.html:2032`)

Each per-card div tagged:
- `.forum-card-title-th` → `.th-only`
- `.forum-card-title-en` → `.en-only`
- `.forum-card-summary-th` / `-en` → same
- `.forum-card-take-th` / `-en` → same
- The `OUR TAKE · มุมของหนัง` label split into two toggled spans

### CSS booster (around `index.html:315`)

When `body.lang-en` is active, EN forum elements get promoted from secondary "subtext" styling (small / dim / muted color) up to primary styling (full size, full opacity, primary text color). Without this the EN side would look weak when it's the only visible content — because it was originally designed as the dim secondary block under the TH primary.

## What did NOT change

- `forum-daily.json` schema — still uses `title_th/en`, `summary_th/en`, `take_th/en`
- Universal labels: `forum-eyebrow` (`BLOCK ··· · SOURCE: bitcointalk.org`), `forum-meta` (`CURATED ··· · COUNT N/21`), `TOPIC NN / 21`, `VERIFY ↗`, the `author · board` line, and the terminal-style skeleton text — all left language-neutral on purpose (terminal aesthetic)
- The `renderForumCards` data flow / fetch / animation / fallback are untouched

## Diff size

+26 / −13 lines, all in `index.html`.

## Test plan

- [ ] Load page in TH mode (default) — confirm forum shows only Thai content (titles, subtitle, disclosure, cards, attribution)
- [ ] Click `EN / TH` in the nav → confirm forum switches to English-only — and EN typography looks primary, not the old dim subtext
- [ ] Click again → confirm switch back to Thai
- [ ] Scroll cards on mobile (375px width) — confirm no layout regression in single-language mode
- [ ] Confirm the Thai disclosure / attribution paraphrase reads naturally (Sarabun register, not literal translation) — owner edit if needed