### PR TITLE
fix: add EN counterparts to TH-only orphan UI elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -396,7 +396,7 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
         <span class="th-only">สุ่มภาพถัดไป</span>
         <span class="en-only">NEXT PHOTO</span>
       </button>
-      <a href="#" target="_blank" class="pb-verify" id="pbLink">🔗 VERIFY SOURCE</a>
+      <a href="#" target="_blank" class="pb-verify" id="pbLink"><span class="th-only">🔗 ตรวจสอบแหล่งที่มา</span><span class="en-only">🔗 VERIFY SOURCE</span></a>
     </div>
   </div>
 </div>
@@ -1296,7 +1296,9 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
     </div>
     <div class="you-koan">
       <p class="th-only">"ถ้าคุณถือ 1 sat — คุณคือ 1 ใน 2,100,000,000,000,000 ของ Satoshi"</p>
+      <p class="en-only">"If you hold 1 sat — you are 1 of 2,100,000,000,000,000 parts of Satoshi."</p>
       <p class="th-only koan-final">"ถ้าคุณ verify ด้วยตัวเอง — คุณคือ Satoshi ทั้งหมด"</p>
+      <p class="en-only koan-final">"If you verify for yourself — you are all of Satoshi."</p>
       
       <div class="quote-box">
         <div class="quote-hash" id="quoteHash">0000000000000000000000000000000000000000000000000000000000000000</div>
@@ -1485,19 +1487,23 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
   <div class="footer-newsletter">
     <div class="footer-newsletter-label">
       <span class="th-only">SUBSCRIBE — รับข่าวสาร</span>
+      <span class="en-only">SUBSCRIBE — STAY IN THE LOOP</span>
     </div>
     <p class="footer-newsletter-desc th-only">รับอัปเดตเกี่ยวกับหนัง ความคืบหน้า และ community events — ไม่มี spam ไม่มีการขาย</p>
+    <p class="footer-newsletter-desc en-only">Get film updates, progress notes, and community event invites — no spam, no selling.</p>
     <div class="footer-newsletter-form" id="newsletterForm">
       <input type="email" class="footer-newsletter-input" id="newsletterEmail" placeholder="your@email.com">
       <button class="footer-newsletter-btn" onclick="subscribeNewsletter()">
-        <span class="th-only">SUBSCRIBE</span>
+        <span>SUBSCRIBE</span>
       </button>
     </div>
     <div class="footer-newsletter-success" id="newsletterSuccess">
       <span class="th-only">✓ SUBSCRIBED — ขอบคุณที่ร่วม verify</span>
+      <span class="en-only">✓ SUBSCRIBED — thanks for joining the verify.</span>
     </div>
     <div class="footer-newsletter-privacy">
       <span class="th-only">EMAIL ของคุณจะไม่ถูกแชร์ — DON'T TRUST, VERIFY</span>
+      <span class="en-only">Your email will not be shared — DON'T TRUST, VERIFY.</span>
     </div>
   </div>
 
@@ -1508,7 +1514,9 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
     <div class="footer-copy">© 2026 SATOSHI FILM — CONFIDENTIAL</div>
     <div class="footer-links">
       <a href="https://app.gitbook.com/invite/CC1p6uOmzX05YyLDPevJ/r3fCPzAmLSaX2XHCIdgr" target="_blank" class="th-only">ร่วมพัฒนาบทภาพยนตร์</a>
+      <a href="https://app.gitbook.com/invite/CC1p6uOmzX05YyLDPevJ/r3fCPzAmLSaX2XHCIdgr" target="_blank" class="en-only">SCRIPT &amp; DOC COLLAB</a>
       <a href="https://github.com/sootisooti/satoshi.film" target="_blank" class="th-only">ร่วมพัฒนาเว็บไซต์</a>
+      <a href="https://github.com/sootisooti/satoshi.film" target="_blank" class="en-only">WEBSITE COLLAB</a>
       <a href="#" onclick="toggleLang(); return false;" style="margin-left: 20px;">
         <span>EN / TH</span>
       </a>


### PR DESCRIPTION
## Summary

Walked the entire `index.html` looking for elements wrapped with `.th-only` that had no matching `.en-only` sibling (or vice versa). In EN mode those elements went silently empty — making the **footer newsletter form, the You-Koan ending, and the Photobook source link look broken** (or simply disappear) for English-mode visitors.

This PR fixes the small, structural orphans. Larger editorial gaps (Cypherpunk Directory + Halving timeline) are flagged below for follow-up.

## What's fixed

| Location | Was | Now |
|---|---|---|
| Photobook modal `pb-verify` link | Hard-coded `🔗 VERIFY SOURCE` with no toggle | Wrapped in `.th-only` / `.en-only` spans, Thai counterpart added |
| You-Koan section (`#cypherpunk` end) | Two TH-only paraphrased koan lines | EN paraphrases added |
| Footer newsletter label | TH-only `SUBSCRIBE — รับข่าวสาร` | + EN `SUBSCRIBE — STAY IN THE LOOP` |
| Footer newsletter description | TH-only paragraph | + EN paragraph |
| Footer newsletter SUBSCRIBE button | Wrapped in `.th-only` (so empty in EN!) | Unwrapped — same word in both languages |
| Footer newsletter success / privacy notes | TH-only spans | + EN spans |
| Footer collab links (`ร่วมพัฒนาบทภาพยนตร์` / `ร่วมพัฒนาเว็บไซต์`) | TH-only links — footer empty for EN visitors | + `SCRIPT & DOC COLLAB` / `WEBSITE COLLAB` mirroring the nav links |

## Diff size

+10 / −2 lines, all in `index.html`.

## Out of scope — needs separate editorial work

These were found during the audit but are **NOT appropriate to translate automatically** in a structural fix PR:

### Cypherpunk Directory — ~80 TH-only `bundle-role` / `ch-subtitle` entries

Every figure in the directory has a Thai descriptor like `"ผู้สร้าง Bitcoin — ผู้ไร้ตัวตน ที่ให้ตัวตนกับทุกคน"`. These read in the film's editorial voice and need careful English translations that match the same tone — not literal renderings. **Recommend a dedicated editorial PR (or split across the 9 chapter groups, one PR each).**

### Halving timeline — 7 TH-only `halving-crisis-text` entries

Each halving cycle has a Thai description tying the macro event to the mining narrative. Same reason — needs editorial voice, not automated translation.

## Out of scope — verify intent before changing

These look intentional but flagging in case they're not:

- **Auth modal form labels**: `LOGIN`, `REGISTER`, `EMAIL OR NPUB`, `PASSWORD`, `DISPLAY NAME`, `CONFIRM PASSWORD`, `CREATE ACCOUNT`, `OR` — all unwrapped English. Read as stylized terminal-style UI controls.
- **`UI MOCKUP — BACKEND PENDING`** badge on the support / zap modal.
- **Footer copyright**: `© 2026 SATOSHI FILM — CONFIDENTIAL` — reads as a universal legal/branding line.

If any of those should actually be bilingual, let me know and I'll open a follow-up.

## Test plan

- [ ] Load page in TH mode (default) — confirm Thai versions render where added (no double-display)
- [ ] Click `EN / TH` in nav → scroll to footer — confirm SUBSCRIBE form, success state, and collab links are no longer empty
- [ ] In EN mode, scroll to the You-Koan section near the end of `#cypherpunk` — confirm English koan lines render
- [ ] In EN mode, open the Photobook (`[ ENTER PHOTOBOOK ]` in nav) — confirm `🔗 VERIFY SOURCE` still shows; switch to TH and confirm `🔗 ตรวจสอบแหล่งที่มา` shows