### PR TITLE
fix: add EN counterpart to seed-caption koan line

### DIFF
--- a/index.html
+++ b/index.html
@@ -1333,7 +1333,8 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
             <div class="seed-grid" id="seedGrid" style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; margin-bottom: 24px;">
               </div>
             <button onclick="generateSeedWords()" style="font-family: 'Space Mono', monospace; font-size: 11px; letter-spacing: 2px; color: #080806; background: #F7931A; border: none; padding: 12px 24px; cursor: none; transition: all 0.3s; margin-bottom: 20px;">GENERATE ⚡</button>
-            <div class="seed-caption">"วันนี้คุณเริ่มปลูกเมล็ดพันธุ์แห่งอิสระภาพของคุณเองแล้วหรือยัง"</div>
+            <div class="seed-caption th-only">"วันนี้คุณเริ่มปลูกเมล็ดพันธุ์แห่งอิสระภาพของคุณเองแล้วหรือยัง"</div>
+            <div class="seed-caption en-only">"Have you started planting your own seed of freedom today?"</div>
           </div>
       </div>
       


### PR DESCRIPTION
## Summary

Follow-up to PR #10 — I pushed this commit after PR #10 had already been merged, so it never made it into `main`. Opening it as its own PR.

Fixes the seed-caption koan that was reported still showing in Thai while in EN mode:

> "วันนี้คุณเริ่มปลูกเมล็ดพันธุ์แห่งอิสระภาพของคุณเองแล้วหรือยัง"

## What changed

`index.html:1322` — the `.seed-caption` div under the BIP-39 **GENERATE ⚡** button in the `YOU — THE VERIFIER` chapter had no toggle wrapper, so its Thai text always showed regardless of language.

- Wrap existing TH text in `.th-only`
- Add `.en-only` counterpart: `"Have you started planting your own seed of freedom today?"`

The EN paraphrase preserves the intentional double meaning — **seed** as in the 12-word BIP-39 seed phrase just generated above it, and **seed of freedom** as the contemplative image.

## Diff size

+2 / −1 lines in `index.html`.

## Test plan

- [ ] Load in TH mode → scroll to the YOU — THE VERIFIER chapter → confirm Thai caption shows under the `GENERATE ⚡` button as before
- [ ] Toggle EN/TH → confirm the caption switches to the English version (no double-display, no empty space)