### PR TITLE
Add EN counterparts for Cypherpunk Directory editorial entries

### DIFF
--- a/index.html
+++ b/index.html
@@ -738,6 +738,7 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
       <div class="ch-info">
         <div class="ch-title">THE WHITEPAPER — GENESIS</div>
         <div class="ch-subtitle th-only">ผู้ที่ Satoshi อ้างอิง — รากฐานที่ถูกเขียนลงใน whitepaper</div>
+        <div class="ch-subtitle en-only">Those Satoshi cited — the foundations written into the whitepaper.</div>
       </div>
     </div>
     <div class="ch-grid">
@@ -752,6 +753,7 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
         <button class="verify-btn" onclick="openTerminal('dorian')">✅ Verify</button>
         <div class="bundle-name">Dorian Prentice Satoshi Nakamoto</div>
         <div class="bundle-role th-only">ชายผู้ถูกสื่อชี้เป้าว่าเป็นผู้สร้าง Bitcoin แต่เขาปฏิเสธอย่างสิ้นเชิง</div>
+        <div class="bundle-role en-only">The man the press named as Bitcoin's creator — a claim he flatly denied.</div>
         <div class="bundle-tags"><span>Newsweek 2014</span><span>Not Satoshi</span></div>
         <div class="bundle-score">0%</div>
       </div>
@@ -759,6 +761,7 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
         <button class="verify-btn" onclick="openTerminal('back')">✅ Verify</button>
         <div class="bundle-name">Adam Back</div>
         <div class="bundle-role th-only">Hashcash 1997 — อ้างอิงใน whitepaper [1]</div>
+        <div class="bundle-role en-only">Hashcash 1997 — cited in the whitepaper [1].</div>
         <div class="bundle-tags"><span>Hashcash</span><span>Ref [1]</span></div>
         <div class="bundle-score">75%</div>
       </div>
@@ -766,6 +769,7 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
         <button class="verify-btn" onclick="openTerminal('weidai')">✅ Verify</button>
         <div class="bundle-name">Wei Dai</div>
         <div class="bundle-role th-only">b-money 1998 — อ้างอิงใน whitepaper [2]</div>
+        <div class="bundle-role en-only">b-money 1998 — cited in the whitepaper [2].</div>
         <div class="bundle-tags"><span>b-money</span><span>Ref [2]</span></div>
         <div class="bundle-score">85%</div>
       </div>
@@ -773,24 +777,28 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
         <button class="verify-btn" onclick="openTerminal('stornetta')">✅ Verify</button>
         <div class="bundle-name">W. Scott Stornetta</div>
         <div class="bundle-role th-only">Timestamped chain 1991 — อ้างอิงใน whitepaper</div>
+        <div class="bundle-role en-only">Timestamped chain 1991 — cited in the whitepaper.</div>
         <div class="bundle-tags"><span>Timestamp Server</span></div>
       </div>
       <div class="bundle-card" data-bundle="haber">
         <button class="verify-btn" onclick="openTerminal('haber')">✅ Verify</button>
         <div class="bundle-name">Stuart Haber</div>
         <div class="bundle-role th-only">Co-author ระบบ timestamping ร่วมกับ Stornetta</div>
+        <div class="bundle-role en-only">Co-author of the timestamping system, with Stornetta.</div>
         <div class="bundle-tags"><span>Surety</span></div>
       </div>
       <div class="bundle-card" data-bundle="merkle">
         <button class="verify-btn" onclick="openTerminal('merkle')">✅ Verify</button>
         <div class="bundle-name">Ralph Merkle</div>
         <div class="bundle-role th-only">Merkle Tree — โครงสร้างข้อมูลที่ทำให้ Bitcoin verify ได้</div>
+        <div class="bundle-role en-only">Merkle Tree — the data structure that lets Bitcoin be verified.</div>
         <div class="bundle-tags"><span>Merkle Tree</span></div>
       </div>
       <div class="bundle-card bundle-genesis" data-bundle="szabo">
         <button class="verify-btn" onclick="openTerminal('szabo')">✅ Verify</button>
         <div class="bundle-name">Nick Szabo</div>
         <div class="bundle-role th-only">Bit Gold & Smart Contracts — ใกล้ Satoshi ที่สุด</div>
+        <div class="bundle-role en-only">Bit Gold & Smart Contracts — closest to Satoshi of anyone named.</div>
         <div class="bundle-tags"><span>Bit Gold</span><span>Smart Contracts</span></div>
         <div class="bundle-score">96%</div>
       </div>
@@ -798,6 +806,7 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
         <button class="verify-btn" onclick="openTerminal('chaum')">✅ Verify</button>
         <div class="bundle-name">David Chaum</div>
         <div class="bundle-role th-only">DigiCash & eCash — บิดาแห่ง digital money ก่อน Bitcoin 25 ปี</div>
+        <div class="bundle-role en-only">DigiCash & eCash — father of digital money, 25 years before Bitcoin.</div>
         <div class="bundle-tags"><span>DigiCash 1989</span></div>
         <div class="bundle-score">80%</div>
       </div>
@@ -810,6 +819,7 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
       <div class="ch-info">
         <div class="ch-title">THE CYPHERPUNKS</div>
         <div class="ch-subtitle th-only">ผู้จุดไฟ — ผู้ที่เชื่อว่าความลับคืออาวุธสุดท้ายของประชาชน</div>
+        <div class="ch-subtitle en-only">The ones who lit the fire — who believed secrecy is the people's last weapon.</div>
       </div>
     </div>
     <div class="ch-grid">
@@ -817,30 +827,35 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
         <button class="verify-btn" onclick="openTerminal('assange')">✅ Verify</button>
         <div class="bundle-name">Julian Assange</div>
         <div class="bundle-role th-only">ผู้ก่อตั้ง WikiLeaks — พิสูจน์ว่าความจริงมีราคา</div>
+        <div class="bundle-role en-only">Founder of WikiLeaks — proof that truth has a price.</div>
         <div class="bundle-tags"><span>WikiLeaks</span><span>PGP</span></div>
       </div>
       <div class="bundle-card" data-bundle="snowden">
         <button class="verify-btn" onclick="openTerminal('snowden')">✅ Verify</button>
         <div class="bundle-name">Edward Snowden</div>
         <div class="bundle-role th-only">NSA Whistleblower — พิสูจน์ว่ารัฐบาลสอดแนมทุกคน</div>
+        <div class="bundle-role en-only">NSA Whistleblower — proof the state watches everyone.</div>
         <div class="bundle-tags"><span>PRISM</span><span>Privacy</span></div>
       </div>
       <div class="bundle-card" data-bundle="appelbaum">
         <button class="verify-btn" onclick="openTerminal('appelbaum')">✅ Verify</button>
         <div class="bundle-name">Jacob Appelbaum</div>
         <div class="bundle-role th-only">Tor Developer — ผู้สร้างเกราะล่องหนบนอินเทอร์เน็ต</div>
+        <div class="bundle-role en-only">Tor Developer — builder of the internet's cloak of invisibility.</div>
         <div class="bundle-tags"><span>Tor Project</span></div>
       </div>
       <div class="bundle-card" data-bundle="muller-maguhn">
         <button class="verify-btn" onclick="openTerminal('muller-maguhn')">✅ Verify</button>
         <div class="bundle-name">Andy Müller-Maguhn</div>
         <div class="bundle-role th-only">CCC / Wau Holland Foundation</div>
+        <div class="bundle-role en-only">CCC / Wau Holland Foundation — German hacker ethic, persistent and quiet.</div>
         <div class="bundle-tags"><span>Chaos Computer Club</span></div>
       </div>
       <div class="bundle-card" data-bundle="hughes">
         <button class="verify-btn" onclick="openTerminal('hughes')">✅ Verify</button>
         <div class="bundle-name">Eric Hughes</div>
         <div class="bundle-role th-only">ผู้เขียน A Cypherpunk's Manifesto</div>
+        <div class="bundle-role en-only">Author of A Cypherpunk's Manifesto.</div>
         <div class="bundle-tags"><span>Manifesto 1993</span></div>
         <div class="bundle-score">79%</div>
       </div>
@@ -848,6 +863,7 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
         <button class="verify-btn" onclick="openTerminal('sassaman')">✅ Verify</button>
         <div class="bundle-name">Len Sassaman</div>
         <div class="bundle-role th-only">Remailer developer / Mixmaster</div>
+        <div class="bundle-role en-only">Remailer developer / Mixmaster — anonymity infrastructure before it had a name.</div>
         <div class="bundle-tags"><span>Mixmaster</span></div>
         <div class="bundle-score">86%</div>
       </div>
@@ -855,6 +871,7 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
         <button class="verify-btn" onclick="openTerminal('may')">✅ Verify</button>
         <div class="bundle-name">Timothy May</div>
         <div class="bundle-role th-only">ผู้เขียน Crypto Anarchist Manifesto 1988</div>
+        <div class="bundle-role en-only">Author of the Crypto Anarchist Manifesto, 1988.</div>
         <div class="bundle-tags"><span>BlackNet</span></div>
         <div class="bundle-score">74%</div>
       </div>
@@ -867,6 +884,7 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
       <div class="ch-info">
         <div class="ch-title">THE PIONEERS & EDUCATORS</div>
         <div class="ch-subtitle th-only">ผู้สร้างและผู้สอน — จาก whitepaper สู่ห้องเรียนของโลก</div>
+        <div class="ch-subtitle en-only">Builders and teachers — from the whitepaper to the world's classroom.</div>
       </div>
     </div>
     <div class="ch-grid">
@@ -874,6 +892,7 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
         <button class="verify-btn" onclick="openTerminal('finney')">✅ Verify</button>
         <div class="bundle-name">Hal Finney</div>
         <div class="bundle-role th-only">ผู้รับ Bitcoin transaction แรก — Running bitcoin.</div>
+        <div class="bundle-role en-only">Recipient of the first Bitcoin transaction — Running bitcoin.</div>
         <div class="bundle-tags"><span>RPOW</span><span>First TX</span></div>
         <div class="bundle-score">90%</div>
       </div>
@@ -881,18 +900,21 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
         <button class="verify-btn" onclick="openTerminal('andreas')">✅ Verify</button>
         <div class="bundle-name">Andreas Antonopoulos</div>
         <div class="bundle-role th-only">ครูของโลก Bitcoin — ผู้ทำให้คนธรรมดาเข้าใจ</div>
+        <div class="bundle-role en-only">Bitcoin's global teacher — the one who made ordinary people understand.</div>
         <div class="bundle-tags"><span>Mastering Bitcoin</span></div>
       </div>
       <div class="bundle-card" data-bundle="song">
         <button class="verify-btn" onclick="openTerminal('song')">✅ Verify</button>
         <div class="bundle-name">Jimmy Song</div>
         <div class="bundle-role th-only">ผู้สอนนักพัฒนา Bitcoin ชั้นนำ — อธิบายด้วยความจริงและตัวโค้ด</div>
+        <div class="bundle-role en-only">Teacher to leading Bitcoin developers — explains through truth and code.</div>
         <div class="bundle-tags"><span>Programming Bitcoin</span></div>
       </div>
       <div class="bundle-card" data-bundle="myfirstbitcoin">
         <button class="verify-btn" onclick="openTerminal('myfirstbitcoin')">✅ Verify</button>
         <div class="bundle-name">My First Bitcoin</div>
         <div class="bundle-role th-only">องค์กรการศึกษาที่ตั้งใจสอนเรื่องอิสรภาพทางการเงินผ่าน Bitcoin ให้กับนักเรียนทั่วโลก เริ่มต้นจากเอลซัลวาดอร์</div>
+        <div class="bundle-role en-only">An education initiative teaching financial freedom through Bitcoin to students worldwide — rooted in El Salvador.</div>
         <div class="bundle-tags"><span>Education</span><span>Mi Primer Bitcoin</span></div>
       </div>
     </div>
@@ -904,6 +926,7 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
       <div class="ch-info">
         <div class="ch-title">THE CORE ARCHITECTS & MAINTAINERS</div>
         <div class="ch-subtitle th-only">ผู้ดูแลวิหาร — ผู้ที่รักษา code ให้บริสุทธิ์โดยไม่มีใครจ้าง</div>
+        <div class="ch-subtitle en-only">Keepers of the temple — who hold the code clean, paid by no one.</div>
       </div>
     </div>
     <div class="ch-grid">
@@ -911,36 +934,42 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
         <button class="verify-btn" onclick="openTerminal('andresen')">✅ Verify</button>
         <div class="bundle-name">Gavin Andresen</div>
         <div class="bundle-role th-only">Lead maintainer คนแรกหลัง Satoshi จากไป</div>
+        <div class="bundle-role en-only">First lead maintainer after Satoshi stepped away.</div>
         <div class="bundle-tags"><span>Bitcoin Core</span></div>
       </div>
       <div class="bundle-card" data-bundle="wuille">
         <button class="verify-btn" onclick="openTerminal('wuille')">✅ Verify</button>
         <div class="bundle-name">Pieter Wuille</div>
         <div class="bundle-role th-only">SegWit / Taproot architect — เปลี่ยน DNA ของ Bitcoin อย่างเงียบๆ</div>
+        <div class="bundle-role en-only">SegWit / Taproot architect — quietly rewrote Bitcoin's DNA.</div>
         <div class="bundle-tags"><span>BIP-141 SegWit</span></div>
       </div>
       <div class="bundle-card" data-bundle="maxwell">
         <button class="verify-btn" onclick="openTerminal('maxwell')">✅ Verify</button>
         <div class="bundle-name">Gregory Maxwell</div>
         <div class="bundle-role th-only">Cryptographer — ผู้ปกป้อง decentralization อย่างดุเดือด</div>
+        <div class="bundle-role en-only">Cryptographer — a fierce defender of decentralization.</div>
         <div class="bundle-tags"><span>Confidential TX</span></div>
       </div>
       <div class="bundle-card" data-bundle="wladimir">
         <button class="verify-btn" onclick="openTerminal('wladimir')">✅ Verify</button>
         <div class="bundle-name">Wladimir van der Laan</div>
         <div class="bundle-role th-only">Lead maintainer 2014–2022 — ผู้ถือกุญแจโดยไม่มีใครรู้หน้า</div>
+        <div class="bundle-role en-only">Lead maintainer 2014–2022 — held the keys while almost no one knew his face.</div>
         <div class="bundle-tags"><span>8 Years Lead</span></div>
       </div>
       <div class="bundle-card" data-bundle="zhao">
         <button class="verify-btn" onclick="openTerminal('zhao')">✅ Verify</button>
         <div class="bundle-name">Gloria Zhao</div>
         <div class="bundle-role th-only">Mempool policy lead — คนรุ่นใหม่ที่ดูแล transaction pool</div>
+        <div class="bundle-role en-only">Mempool policy lead — a new generation tending the transaction pool.</div>
         <div class="bundle-tags"><span>Mempool Policy</span></div>
       </div>
       <div class="bundle-card" data-bundle="ford">
         <button class="verify-btn" onclick="openTerminal('ford')">✅ Verify</button>
         <div class="bundle-name">Michael Ford</div>
         <div class="bundle-role th-only">Current lead maintainer — สืบทอดหน้าที่ดูแล code</div>
+        <div class="bundle-role en-only">Current lead maintainer — inheriting the duty of tending the code.</div>
         <div class="bundle-tags"><span>Bitcoin Core</span></div>
       </div>
     </div>
@@ -952,6 +981,7 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
       <div class="ch-info">
         <div class="ch-title">SCALING, SOVEREIGNTY & FUTURE-PROOFING</div>
         <div class="ch-subtitle th-only">ผู้ขยาย ผู้คืนอำนาจ ผู้เตรียมพร้อม — สร้างโครงสร้างให้คนธรรมดาใช้ได้จริง</div>
+        <div class="ch-subtitle en-only">Who scale, return sovereignty, and prepare — building the rails ordinary people can actually use.</div>
       </div>
     </div>
     <div class="ch-grid">
@@ -959,42 +989,49 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
         <button class="verify-btn" onclick="openTerminal('lightning')">✅ Verify</button>
         <div class="bundle-name">Lightning Network</div>
         <div class="bundle-role th-only">Elizabeth Stark & Lightning Labs — ทำให้ Bitcoin เร็วพอสำหรับกาแฟหนึ่งแก้ว</div>
+        <div class="bundle-role en-only">Elizabeth Stark & Lightning Labs — making Bitcoin fast enough for a cup of coffee.</div>
         <div class="bundle-tags"><span>Layer 2</span><span>Payment Channels</span></div>
       </div>
       <div class="bundle-card bundle-tech" data-bundle="taproot">
         <button class="verify-btn" onclick="openTerminal('taproot')">✅ Verify</button>
         <div class="bundle-name">Taproot Upgrade</div>
         <div class="bundle-role th-only">BIP-340/341/342 — ความเป็นส่วนตัวและ smart contract บน Bitcoin</div>
+        <div class="bundle-role en-only">BIP-340/341/342 — privacy and smart contracts on Bitcoin.</div>
         <div class="bundle-tags"><span>Schnorr Signatures</span></div>
       </div>
       <div class="bundle-card bundle-tech" data-bundle="umbrel">
         <button class="verify-btn" onclick="openTerminal('umbrel')">✅ Verify</button>
         <div class="bundle-name">Umbrel</div>
         <div class="bundle-role th-only">Node ส่วนตัว — Don't Trust, Verify ที่จับต้องได้ ทุกคนรัน Node ได้</div>
+        <div class="bundle-role en-only">A personal node — Don't Trust, Verify, made tangible. Anyone can run one.</div>
         <div class="bundle-tags"><span>Full Node</span></div>
       </div>
       <div class="bundle-card bundle-tech bundle-quantum" data-bundle="bip360">
         <button class="verify-btn" onclick="openTerminal('bip360')">✅ Verify</button>
         <div class="bundle-name">BIP-360</div>
         <div class="bundle-role th-only">Pay-to-Quantum-Resistant-Hash — เตรียมพร้อมสู่ยุคหลัง quantum</div>
+        <div class="bundle-role en-only">Pay-to-Quantum-Resistant-Hash — preparing for the post-quantum era.</div>
         <div class="bundle-tags"><span>Quantum Resistance</span></div>
       </div>
       <div class="bundle-card bundle-tech" data-bundle="braiins">
         <button class="verify-btn" onclick="openTerminal('braiins')">✅ Verify</button>
         <div class="bundle-name">Braiins (Slush Pool)</div>
         <div class="bundle-role th-only">Mining pool แห่งแรกของโลก และผู้ผลักดัน Stratum V2 ให้การขุดกระจายศูนย์</div>
+        <div class="bundle-role en-only">The world's first mining pool, and the force behind Stratum V2 — keeping mining decentralized.</div>
         <div class="bundle-tags"><span>Slush Pool</span><span>Stratum V2</span></div>
       </div>
       <div class="bundle-card bundle-tech" data-bundle="blockstream">
         <button class="verify-btn" onclick="openTerminal('blockstream')">✅ Verify</button>
         <div class="bundle-name">Blockstream</div>
         <div class="bundle-role th-only">Adam Back และทีมงาน — ผู้สร้างโครงสร้างพื้นฐานระดับโลก ทั้ง Liquid Network และการยิงสัญญาณ Blockchain ผ่านดาวเทียม</div>
+        <div class="bundle-role en-only">Adam Back and team — global infrastructure, from Liquid Network to broadcasting the blockchain via satellite.</div>
         <div class="bundle-tags"><span>Infrastructure</span><span>Satellite</span></div>
       </div>
       <div class="bundle-card bundle-biz" data-bundle="welb">
         <button class="verify-btn" onclick="openTerminal('welb')">✅ Verify</button>
         <div class="bundle-name">WelB</div>
         <div class="bundle-role th-only">ร้านค้ารับ Bitcoin — ผลักดันเศรษฐกิจคู่ขนานด้วยการรับชำระและสนับสนุนระบบ Lightning Network</div>
+        <div class="bundle-role en-only">Merchants accepting Bitcoin — building a parallel economy, one Lightning payment at a time.</div>
         <div class="bundle-tags"><span>Merchant</span><span>Lightning Network</span></div>
       </div>
     </div>
@@ -1006,6 +1043,7 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
       <div class="ch-info">
         <div class="ch-title">THE SIGNAL AMPLIFIERS</div>
         <div class="ch-subtitle th-only">ผู้ขยายสัญญาณ — ผู้ที่ทำให้โลกได้ยิน ไม่ว่าจะเห็นด้วยหรือไม่</div>
+        <div class="ch-subtitle en-only">Signal amplifiers — who make the world listen, whether it agrees or not.</div>
       </div>
     </div>
     <div class="ch-grid">
@@ -1013,24 +1051,28 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
         <button class="verify-btn" onclick="openTerminal('nostr')">✅ Verify</button>
         <div class="bundle-name">Nostr Protocol</div>
         <div class="bundle-role th-only">William Casarin / Damus / Zap — social media ที่ไม่มีใครปิดได้</div>
+        <div class="bundle-role en-only">William Casarin / Damus / Zap — social media no one can shut down.</div>
         <div class="bundle-tags"><span>Decentralized Social</span></div>
       </div>
       <div class="bundle-card bundle-signal" data-bundle="dorsey">
         <button class="verify-btn" onclick="openTerminal('dorsey')">✅ Verify</button>
         <div class="bundle-name">Jack Dorsey</div>
         <div class="bundle-role th-only">Twitter → Nostr → Block, Inc. — จาก centralized สู่ open protocol</div>
+        <div class="bundle-role en-only">Twitter → Nostr → Block, Inc. — from centralized platforms toward open protocols.</div>
         <div class="bundle-tags"><span>Block Inc.</span></div>
       </div>
       <div class="bundle-card bundle-signal" data-bundle="musk">
         <button class="verify-btn" onclick="openTerminal('musk')">✅ Verify</button>
         <div class="bundle-name">Elon Musk</div>
         <div class="bundle-role th-only">สัญญาณที่ขยายทั้งสองทาง — ทั้งเชื่อและต้องตรวจสอบ</div>
+        <div class="bundle-role en-only">A signal that amplifies both ways — reason to believe, and reason to verify.</div>
         <div class="bundle-tags"><span>Tesla BTC</span></div>
       </div>
       <div class="bundle-card bundle-signal" data-bundle="thiel">
         <button class="verify-btn" onclick="openTerminal('thiel')">✅ Verify</button>
         <div class="bundle-name">Peter Thiel</div>
         <div class="bundle-role th-only">PayPal → Palantir → Bitcoin maximalist — ผู้เห็นอนาคตก่อนตลาด</div>
+        <div class="bundle-role en-only">PayPal → Palantir → Bitcoin maximalist — saw the future before the market did.</div>
         <div class="bundle-tags"><span>Founders Fund</span></div>
       </div>
     </div>
@@ -1042,6 +1084,7 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
       <div class="ch-info">
         <div class="ch-title">THE WRITERS</div>
         <div class="ch-subtitle th-only">ผู้บันทึก — ผู้ที่แปลงรหัสให้เป็นภาษาที่โลกอ่านออก</div>
+        <div class="ch-subtitle en-only">The recorders — who turn code into language the world can read.</div>
       </div>
     </div>
     <div class="ch-grid">
@@ -1049,36 +1092,42 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
         <button class="verify-btn" onclick="openTerminal('ammous')">✅ Verify</button>
         <div class="bundle-name">Saifedean Ammous</div>
         <div class="bundle-role th-only">The Bitcoin Standard — หนังสือที่เปลี่ยนวิธีคิดของคนทั้งรุ่น</div>
+        <div class="bundle-role en-only">The Bitcoin Standard — the book that reshaped how a generation thinks about money.</div>
         <div class="bundle-tags"><span>The Bitcoin Standard</span></div>
       </div>
       <div class="bundle-card" data-bundle="alden">
         <button class="verify-btn" onclick="openTerminal('alden')">✅ Verify</button>
         <div class="bundle-name">Lyn Alden</div>
         <div class="bundle-role th-only">Broken Money — วิเคราะห์ระบบการเงินด้วยข้อมูลจริง ไม่ใช่ความเชื่อ</div>
+        <div class="bundle-role en-only">Broken Money — analyzing the financial system with data, not belief.</div>
         <div class="bundle-tags"><span>Broken Money</span></div>
       </div>
       <div class="bundle-card" data-bundle="bhatia">
         <button class="verify-btn" onclick="openTerminal('bhatia')">✅ Verify</button>
         <div class="bundle-name">Nik Bhatia</div>
         <div class="bundle-role th-only">Layered Money — อธิบาย Bitcoin ผ่านเลนส์ของประวัติศาสตร์การเงินโลก</div>
+        <div class="bundle-role en-only">Layered Money — Bitcoin seen through the long lens of monetary history.</div>
         <div class="bundle-tags"><span>Layered Money</span></div>
       </div>
       <div class="bundle-card" data-bundle="btcmag">
         <button class="verify-btn" onclick="openTerminal('btcmag')">✅ Verify</button>
         <div class="bundle-name">Bitcoin Magazine</div>
         <div class="bundle-role th-only">สื่อสิ่งพิมพ์แรกของโลก Bitcoin — ก่อตั้งโดย Vitalik Buterin และ Mihai Alisie (2012)</div>
+        <div class="bundle-role en-only">The world's first Bitcoin publication — founded by Vitalik Buterin and Mihai Alisie (2012).</div>
         <div class="bundle-tags"><span>Print Media</span><span>Founded 2012</span></div>
       </div>
       <div class="bundle-card" data-bundle="mininghandbook">
         <button class="verify-btn" onclick="openTerminal('mininghandbook')">✅ Verify</button>
         <div class="bundle-name">BITCOIN MINING HANDBOOK</div>
         <div class="bundle-role th-only">คู่มือแปลไทยจากต้นฉบับ Braiins เจาะลึกกลไกเหมืองขุดและการจัดการพลังงาน (Heat Reuse)</div>
+        <div class="bundle-role en-only">Thai translation of Braiins' original handbook — deep on mining mechanics and heat reuse.</div>
         <div class="bundle-tags"><span>Braiins</span><span>Thai Translation</span></div>
       </div>
       <div class="bundle-card bundle-th" data-bundle="rightshift_writer">
         <button class="verify-btn" onclick="openTerminal('rightshift_writer')">✅ Verify</button>
         <div class="bundle-name">Right Shift</div>
         <div class="bundle-role th-only">สำนักพิมพ์และผู้แปลหนังสือคุณภาพที่ส่งต่อความรู้ด้านเศรษฐศาสตร์และ Bitcoin สู่ภาษาไทย</div>
+        <div class="bundle-role en-only">Publisher and translator — carrying economic and Bitcoin literacy into Thai.</div>
         <div class="bundle-tags"><span>Publisher</span><span>Thai Translation</span></div>
       </div>
     </div>
@@ -1090,6 +1139,7 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
       <div class="ch-info">
         <div class="ch-title">DOCUMENTARY & FILM</div>
         <div class="ch-subtitle th-only">ผู้ถ่ายทอดความจริงบนหน้าจอ — สารคดีที่เปิดโปงและบันทึกประวัติศาสตร์</div>
+        <div class="ch-subtitle en-only">Truth-tellers on screen — documentaries that uncover and keep record.</div>
       </div>
     </div>
     <div class="ch-grid">
@@ -1097,18 +1147,21 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
         <button class="verify-btn" onclick="openTerminal('dirtycoin')">✅ Verify</button>
         <div class="bundle-name">Dirty Coin</div>
         <div class="bundle-role th-only">Alana Mediavilla — สารคดีที่ตีแผ่ความจริงเรื่องเหมือง Bitcoin กับการใช้พลังงานโลก</div>
+        <div class="bundle-role en-only">Alana Mediavilla — a documentary that lays bare the truth about Bitcoin mining and global energy.</div>
         <div class="bundle-tags"><span>Energy FUD</span><span>Mining</span></div>
       </div>
       <div class="bundle-card bundle-doc" data-bundle="hbodoc">
         <button class="verify-btn" onclick="openTerminal('hbodoc')">✅ Verify</button>
         <div class="bundle-name">Money Electric: The Bitcoin Mystery</div>
         <div class="bundle-role th-only">HBO (Cullen Hoback) — สารคดีที่พยายามสืบหาตัวตนของ Satoshi และทฤษฎี Peter Todd</div>
+        <div class="bundle-role en-only">HBO (Cullen Hoback) — a documentary hunting for Satoshi's identity and the Peter Todd theory.</div>
         <div class="bundle-tags"><span>HBO Max</span><span>Cullen Hoback</span></div>
       </div>
       <div class="bundle-card bundle-doc" data-bundle="netflixdoc">
         <button class="verify-btn" onclick="openTerminal('netflixdoc')">✅ Verify</button>
         <div class="bundle-name">Banking on Bitcoin</div>
         <div class="bundle-role th-only">Netflix (2016) — บันทึกยุคบุกเบิกของ Bitcoin ตั้งแต่ Cypherpunks จนถึง Silk Road</div>
+        <div class="bundle-role en-only">Netflix (2016) — a record of Bitcoin's frontier years, from the Cypherpunks to Silk Road.</div>
         <div class="bundle-tags"><span>Netflix</span><span>History</span></div>
       </div>
     </div>
@@ -1120,6 +1173,7 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
       <div class="ch-info">
         <div class="ch-title">THE ENTREPRENEURS</div>
         <div class="ch-subtitle th-only">ผู้เปลี่ยนโลกธุรกิจ — จากกระดานเทรดสู่คลังสมบัติระดับองค์กร</div>
+        <div class="ch-subtitle en-only">Who changed business — from trading desk to corporate treasury.</div>
       </div>
     </div>
     <div class="ch-grid">
@@ -1127,18 +1181,21 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
         <button class="verify-btn" onclick="openTerminal('saylor')">✅ Verify</button>
         <div class="bundle-name">Michael Saylor</div>
         <div class="bundle-role th-only">MicroStrategy — ผู้เปลี่ยนคลังเงินบริษัทให้เป็น Bitcoin Vault ระดับโลก</div>
+        <div class="bundle-role en-only">MicroStrategy — turned a corporate treasury into a world-class Bitcoin vault.</div>
         <div class="bundle-tags"><span>MicroStrategy</span><span>Corporate Treasury</span></div>
       </div>
       <div class="bundle-card bundle-biz" data-bundle="mallers">
         <button class="verify-btn" onclick="openTerminal('mallers')">✅ Verify</button>
         <div class="bundle-name">Jack Mallers</div>
         <div class="bundle-role th-only">Strike — ผู้สร้างสะพานเชื่อม Lightning Network เข้าสู่ระบบการเงินดั้งเดิม</div>
+        <div class="bundle-role en-only">Strike — the bridge connecting Lightning Network to the legacy financial system.</div>
         <div class="bundle-tags"><span>Strike</span><span>Lightning Network</span></div>
       </div>
       <div class="bundle-card bundle-biz" data-bundle="winklevoss">
         <button class="verify-btn" onclick="openTerminal('winklevoss')">✅ Verify</button>
         <div class="bundle-name">Winklevoss Twins</div>
         <div class="bundle-role th-only">Cameron & Tyler Winklevoss — ผู้เชื่อมั่นตั้งแต่ยุคบุกเบิก และสร้างโครงสร้างพื้นฐานเพื่อนักลงทุนระดับโลกผ่าน Gemini</div>
+        <div class="bundle-role en-only">Cameron & Tyler Winklevoss — early believers who built global-grade infrastructure for investors through Gemini.</div>
         <div class="bundle-tags"><span>Entrepreneurs</span><span>Gemini</span></div>
       </div>
     </div>
@@ -1150,6 +1207,7 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
       <div class="ch-info">
         <div class="ch-title">NATION STATE ADOPTION</div>
         <div class="ch-subtitle th-only">การตื่นรู้ของรัฐ — เมื่อประเทศเริ่มทำ proof of work และถือครอง Bitcoin</div>
+        <div class="ch-subtitle en-only">The state awakens — when nations begin their own proof of work and hold Bitcoin.</div>
       </div>
     </div>
     <div class="ch-grid">
@@ -1157,18 +1215,21 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
         <button class="verify-btn" onclick="openTerminal('bukele')">✅ Verify</button>
         <div class="bundle-name">Nayib Bukele (El Salvador)</div>
         <div class="bundle-role th-only">ประธานาธิบดีผู้ทำให้ Bitcoin เป็นเงินที่ชำระหนี้ได้ตามกฎหมายประเทศแรกของโลก</div>
+        <div class="bundle-role en-only">The president who made Bitcoin legal tender — the first country on Earth to do so.</div>
         <div class="bundle-tags"><span>El Salvador</span><span>Legal Tender</span></div>
       </div>
       <div class="bundle-card bundle-biz" data-bundle="bhutan">
         <button class="verify-btn" onclick="openTerminal('bhutan')">✅ Verify</button>
         <div class="bundle-name">Kingdom of Bhutan</div>
         <div class="bundle-role th-only">ประเทศที่แอบทำเหมืองขุด Bitcoin อย่างเงียบๆ ด้วยพลังงานน้ำจากเทือกเขาหิมาลัย</div>
+        <div class="bundle-role en-only">A kingdom quietly mining Bitcoin with Himalayan hydropower.</div>
         <div class="bundle-tags"><span>Bhutan</span><span>Hydro Power</span></div>
       </div>
       <div class="bundle-card bundle-biz" data-bundle="jan3">
         <button class="verify-btn" onclick="openTerminal('jan3')">✅ Verify</button>
         <div class="bundle-name">JAN3</div>
         <div class="bundle-role th-only">Samson Mow — บริษัทที่มุ่งเน้นการผลักดันให้ระดับประเทศ (Nation-State) นำ Bitcoin ไปใช้เป็นทุนสำรองและออกพันธบัตร</div>
+        <div class="bundle-role en-only">Samson Mow — a company pushing nation-states to adopt Bitcoin as reserves and issue sovereign bonds.</div>
         <div class="bundle-tags"><span>Nation-State</span><span>Hyperbitcoinization</span></div>
       </div>
     </div>
@@ -1180,6 +1241,7 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
       <div class="ch-info">
         <div class="ch-title">PHYSICAL SPACES & COMMUNITIES</div>
         <div class="ch-subtitle th-only">พื้นที่โลกจริง — ศูนย์รวมคอมมูนิตี้ที่จับต้องได้นอกเหนือจากโลกออนไลน์</div>
+        <div class="ch-subtitle en-only">Real-world spaces — community gathered in the flesh, not only on screens.</div>
       </div>
     </div>
     <div class="ch-grid">
@@ -1187,72 +1249,84 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
         <button class="verify-btn" onclick="openTerminal('presidio')">✅ Verify</button>
         <div class="bundle-name">Presidio Bitcoin</div>
         <div class="bundle-role th-only">พื้นที่พบปะของชาว Bitcoin เพื่อสร้าง network แบบตัวเป็นๆ นอกหน้าจอ</div>
+        <div class="bundle-role en-only">A gathering place for Bitcoiners to build a network in person, off-screen.</div>
         <div class="bundle-tags"><span>Physical Space</span><span>Community Hub</span></div>
       </div>
       <div class="bundle-card bundle-th" data-bundle="blccm">
         <button class="verify-btn" onclick="openTerminal('blccm')">✅ Verify</button>
         <div class="bundle-name">Bitcoin Learning Center — เชียงใหม่</div>
         <div class="bundle-role th-only">พื้นที่เรียนรู้ Bitcoin จริง ในเมืองจริง — ฐานที่มั่นภาคเหนือ</div>
+        <div class="bundle-role en-only">A real Bitcoin classroom in a real city — the northern outpost.</div>
         <div class="bundle-tags"><span>Chiang Mai</span><span>Education Hub</span></div>
       </div>
       <div class="bundle-card bundle-th" data-bundle="blchatyai">
         <button class="verify-btn" onclick="openTerminal('blchatyai')">✅ Verify</button>
         <div class="bundle-name">BLC หาดใหญ่</div>
         <div class="bundle-role th-only">Bitcoin Learning Center ภาคใต้ — พื้นที่เรียนรู้และส่งต่อความรู้ที่ลึกซึ้งของชาวหาดใหญ่</div>
+        <div class="bundle-role en-only">Bitcoin Learning Center of the south — Hat Yai's space for deep learning and passing knowledge on.</div>
         <div class="bundle-tags"><span>Hat Yai</span><span>Education Hub</span></div>
       </div>
       <div class="bundle-card bundle-th" data-bundle="ybtc">
         <button class="verify-btn" onclick="openTerminal('ybtc')">✅ Verify</button>
         <div class="bundle-name">YBTC — ยะลา</div>
         <div class="bundle-role th-only">Yala Bitcoin Community — ชุมชนชาวบิตคอยเนอร์สุดแดนใต้ ศูนย์รวมการพบปะและศึกษา Bitcoin</div>
+        <div class="bundle-role en-only">Yala Bitcoin Community — Bitcoiners at the country's deep south, gathered to meet and study together.</div>
         <div class="bundle-tags"><span>Yala</span><span>Community Space</span></div>
       </div>
       <div class="bundle-card bundle-th" data-bundle="issaradee">
         <button class="verify-btn" onclick="openTerminal('issaradee')">✅ Verify</button>
         <div class="bundle-name">อิสระดี — เชียงราย</div>
         <div class="bundle-role th-only">Co-playing Space พื้นที่แห่งอิสระ การเรียนรู้ และคอมมูนิตี้ Bitcoin แห่งเชียงราย</div>
+        <div class="bundle-role en-only">A co-playing space — Chiang Rai's room for freedom, learning, and Bitcoin community.</div>
         <div class="bundle-tags"><span>Chiang Rai</span><span>Co-playing Space</span></div>
       </div>
       <div class="bundle-card bundle-th" data-bundle="ageofbitcoin">
         <button class="verify-btn" onclick="openTerminal('ageofbitcoin')">✅ Verify</button>
         <div class="bundle-name">Age of Bitcoin</div>
         <div class="bundle-role th-only">บอร์ดเกมส์จำลองระบบเศรษฐกิจ — เครื่องมือเรียนรู้ที่ให้คุณได้สัมผัสการขุดและการโจมตีเครือข่ายด้วยตัวเอง</div>
+        <div class="bundle-role en-only">A board game that simulates the economy — learn mining and network attacks by playing them.</div>
         <div class="bundle-tags"><span>Board Game</span><span>Education</span></div>
       </div>
       <div class="bundle-card bundle-th" data-bundle="bob">
         <button class="verify-btn" onclick="openTerminal('bob')">✅ Verify</button>
         <div class="bundle-name">B.O.B Space</div>
         <div class="bundle-role th-only">Bitcoin community space — พื้นที่รวมตัวใจกลางกรุงเทพฯ ของเหล่า Bitcoiners</div>
+        <div class="bundle-role en-only">Bitcoin community space — a meeting point at the heart of Bangkok.</div>
         <div class="bundle-tags"><span>Community Space</span><span>Bangkok</span></div>
       </div>
       <div class="bundle-card bundle-th" data-bundle="citadelcafe">
         <button class="verify-btn" onclick="openTerminal('citadelcafe')">✅ Verify</button>
         <div class="bundle-name">CITADEL COFFEE — ปทุมธานี</div>
         <div class="bundle-role th-only">พื้นที่พบปะ พูดคุย แลกเปลี่ยนความรู้ และจิบกาแฟของชาวบิตคอยเนอร์</div>
+        <div class="bundle-role en-only">A place for Bitcoiners to meet, talk, trade ideas — over coffee.</div>
         <div class="bundle-tags"><span>Cafe</span><span>Meetups</span></div>
       </div>
       <div class="bundle-card bundle-th" data-bundle="lankrongmun">
         <button class="verify-btn" onclick="openTerminal('lankrongmun')">✅ Verify</button>
         <div class="bundle-name">ลานกรองมันส์ — ชลบุรี</div>
         <div class="bundle-role th-only">ลานกิจกรรมและจุดรวมพลของสายธรรมไทย สร้าง Proof of Work ผ่านกิจกรรมในโลกจริง</div>
+        <div class="bundle-role en-only">An open courtyard and rally point for the Thai dharma crowd — proof of work through real-world gatherings.</div>
         <div class="bundle-tags"><span>Activity Space</span><span>Meetups</span></div>
       </div>
       <div class="bundle-card bundle-th" data-bundle="chithole">
         <button class="verify-btn" onclick="openTerminal('chithole')">✅ Verify</button>
         <div class="bundle-name">CHIT HOLE</div>
         <div class="bundle-role th-only">พื้นที่บาร์ คราฟต์เบียร์ และคอมมูนิตี้บิตคอยน์ที่ต่อยอดจาก Chit Beer แหล่งรวมบทสนทนาคุณภาพ</div>
+        <div class="bundle-role en-only">Bar, craft beer, Bitcoin community — a Chit Beer offshoot where good conversation pours easily.</div>
         <div class="bundle-tags"><span>Craft Beer</span><span>Bar</span></div>
       </div>
       <div class="bundle-card bundle-th" data-bundle="samakkhi">
         <button class="verify-btn" onclick="openTerminal('samakkhi')">✅ Verify</button>
         <div class="bundle-name">สามัคคีชุมนุม — นครพนม</div>
         <div class="bundle-role th-only">พื้นที่ชุมชนและแหล่งเรียนรู้ Bitcoin กลางแจ้งในจังหวัดนครพนม ขับเคลื่อนโดยคนในพื้นที่เพื่อคนในพื้นที่</div>
+        <div class="bundle-role en-only">An outdoor community and Bitcoin learning spot in Nakhon Phanom — run by locals, for locals.</div>
         <div class="bundle-tags"><span>Nakhon Phanom</span><span>Outdoor Space</span></div>
       </div>
       <div class="bundle-card bundle-th" data-bundle="crackersbook">
         <button class="verify-btn" onclick="openTerminal('crackersbook')">✅ Verify</button>
         <div class="bundle-name">Crackers Books — พิษณุโลก</div>
         <div class="bundle-role th-only">สำนักพิมพ์อิสระและพื้นที่พบปะของนักอ่านและ Bitcoiners ขับเคลื่อนด้วยความรู้และ Proof of Work</div>
+        <div class="bundle-role en-only">An indie publisher and meeting place for readers and Bitcoiners — moved by knowledge and proof of work.</div>
         <div class="bundle-tags"><span>Phitsanulok</span><span>Publishing House</span></div>
       </div>
     </div>
@@ -1264,6 +1338,7 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
       <div class="ch-info">
         <div class="ch-title">THAILAND BITCOINERS — Thailand Bitcoiner Pioneer</div>
         <div class="ch-subtitle th-only">proof of work บนแผ่นดินไทย — คอมมูนิตี้และคนที่ลงมือทำจริง</div>
+        <div class="ch-subtitle en-only">Proof of work on Thai soil — communities and the people actually doing it.</div>
       </div>
     </div>
     <div class="ch-grid">
@@ -1271,30 +1346,35 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
         <button class="verify-btn" onclick="openTerminal('tum')">✅ Verify</button>
         <div class="bundle-name">อาจารย์ตั้ม พิริยะ — Right Shift</div>
         <div class="bundle-role th-only">ผู้สอน Bitcoin ให้คนไทยเข้าใจลึกซึ้ง — รายการ Right Shift Podcast</div>
+        <div class="bundle-role en-only">The teacher bringing Bitcoin home to Thai listeners — the Right Shift Podcast.</div>
         <div class="bundle-tags"><span>Right Shift</span><span>Education</span></div>
       </div>
       <div class="bundle-card bundle-th" data-bundle="siamese">
         <button class="verify-btn" onclick="openTerminal('siamese')">✅ Verify</button>
         <div class="bundle-name">Siamese Bitcoiner</div>
         <div class="bundle-role th-only">กลุ่ม Facebook ศูนย์รวมคนไทยที่รวมตัวพูดคุยและให้ความรู้เรื่อง Bitcoin อย่างแท้จริง</div>
+        <div class="bundle-role en-only">The Facebook group where Thai Bitcoiners actually gather, talk, and teach each other.</div>
         <div class="bundle-tags"><span>Facebook Group</span><span>Community</span></div>
       </div>
       <div class="bundle-card bundle-th" data-bundle="discordth">
         <button class="verify-btn" onclick="openTerminal('discordth')">✅ Verify</button>
         <div class="bundle-name">Bitcoin Local Thailand</div>
         <div class="bundle-role th-only">Discord ชุมชนคนรักบิตคอยน์ชาวไทย ศูนย์รวมการพูดคุยแบบ Real-time</div>
+        <div class="bundle-role en-only">The Thai Bitcoiner Discord — real-time conversation, day and night.</div>
         <div class="bundle-tags"><span>Discord</span><span>Real-time Chat</span></div>
       </div>
       <div class="bundle-card bundle-th" data-bundle="chit">
         <button class="verify-btn" onclick="openTerminal('chit')">✅ Verify</button>
         <div class="bundle-name">พี่ชิต — Chit Beer</div>
         <div class="bundle-role th-only">เชื่อม Bitcoin กับวัฒนธรรม craft — proof of work ในแก้วเบียร์บนเกาะเกร็ด</div>
+        <div class="bundle-role en-only">Bridging Bitcoin and craft culture — proof of work, served in a glass, on Ko Kret.</div>
         <div class="bundle-tags"><span>Chit Beer</span><span>Thai Culture</span></div>
       </div>
       <div class="bundle-card bundle-th" data-bundle="siamstr">
         <button class="verify-btn" onclick="openTerminal('siamstr')">✅ Verify</button>
         <div class="bundle-name">#siamstr</div>
         <div class="bundle-role th-only">พื้นที่สื่อสารของคนไทยในโลกโซเชียลมีเดียแห่งใหม่บน Nostr protocol อิสระจากการเซ็นเซอร์</div>
+        <div class="bundle-role en-only">Thai voices in the new social world on the Nostr protocol — free from censorship.</div>
         <div class="bundle-tags"><span>Nostr</span><span>Thai Community</span></div>
       </div>
     </div>
@@ -1306,6 +1386,7 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
       <div class="ch-info">
         <div class="ch-title ch-title-you">YOU — THE VERIFIER</div>
         <div class="ch-subtitle ch-subtitle-you th-only">ทุกคนที่ถือ sat แม้แค่หนึ่งเดียว — คือ Satoshi</div>
+        <div class="ch-subtitle ch-subtitle-you en-only">Anyone who holds even a single sat — is Satoshi.</div>
       </div>
     </div>
     <div class="you-koan">


### PR DESCRIPTION
## Summary

Closes the last bilingual gap: every `ch-subtitle` and `bundle-role` in the Cypherpunk Directory now has a paired English sibling, matching the Mode B toggle pattern used across the rest of the site.

- 13 `ch-subtitle` entries (12 `ch-group` + 1 `ch-you`)
- 68 `bundle-role` entries across all chapters
- Halving timeline was already done in PR #10 — no changes here

All translations use the film's editorial voice — contemplative, paraphrased, Sarabun register preserved in Thai. No exclamation marks. No "revolutionary" / "game-changer" language. Double meanings (proof of work, verify, seed-of-freedom) kept intact.

## Note: breaks the "keep diffs small" rule

This PR intentionally breaks `CLAUDE.md`'s:

> Keep diffs small. A 500-line diff should probably be 3 smaller PRs.

Per owner's explicit direction (Option B: single large PR for the full editorial pass, rather than splitting by chapter group). Opened as **Draft** for voice review before merge.

## Review checklist (mobile-friendly)

- [ ] Each TH→EN pair reads as a paraphrase, not a literal translation
- [ ] Editorial voice is contemplative, not hype
- [ ] Double meanings preserved (proof of work as philosophy + algorithm)
- [ ] No exclamation marks, no "revolutionary/game-changer"
- [ ] Tap **Files changed** → pencil icon to edit any line inline on mobile

## Test plan
- [ ] Toggle TH/EN on the live site and scan each chapter for missing EN strings
- [ ] Confirm no layout shift — pair count matches (87 th-only / 87 en-only)
- [ ] Verify `ch-you` subtitle toggles correctly
- [ ] Spot-check five random `bundle-role` entries for voice

---
*Opened as Draft. Mark as Ready for Review when voice has been vetted.*