### PR TITLE
fix: add null checks for missing friedcatModal element

### DIFF
--- a/index.html
+++ b/index.html
@@ -2105,11 +2105,18 @@ document.addEventListener('keydown', (e) => {
 const friedcat = document.querySelector('[data-hw="friedcat"]');
 if (friedcat) {
   friedcat.addEventListener('click', () => {
-    document.getElementById('friedcatModal').classList.add('active');
+    const modal = document.getElementById('friedcatModal');
+    if (modal) modal.classList.add('active');
   });
 }
-function closeFriedcat() { document.getElementById('friedcatModal').classList.remove('active'); }
-document.getElementById('friedcatModal').addEventListener('click', (e) => { if (e.target === e.currentTarget) closeFriedcat(); });
+function closeFriedcat() {
+  const modal = document.getElementById('friedcatModal');
+  if (modal) modal.classList.remove('active');
+}
+const friedcatModal = document.getElementById('friedcatModal');
+if (friedcatModal) {
+  friedcatModal.addEventListener('click', (e) => { if (e.target === e.currentTarget) closeFriedcat(); });
+}
 
 document.querySelectorAll('a[href^="#"]').forEach(a => {
   a.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary

Fixes TypeError at line 2112 where `friedcatModal.addEventListener` was called on null.

**Root cause of the error**: The `friedcatModal` element doesn't exist in the DOM, causing a null reference error when attempting to attach an event listener.

**Number of null checks added**: 3

**List of elements that were missing**:
- `friedcatModal` (referenced at lines 2108, 2111, 2112)

**Test plan**: After merge, the main `<script>` block should execute without errors. The red error overlay should no longer appear. The forum section should load 21 cards correctly, and all other features (Verify terminal, scroll animations, custom cursor) should continue working normally.

---

Resolves issue reported in #14

Generated with [Claude Code](https://claude.ai/code)