### PR TITLE
fix: nav mobile overflow + DIALOGUE translation + photobook placeholder

### DIFF
--- a/index.html
+++ b/index.html
@@ -357,7 +357,10 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
   .nav-link { font-size: 9px; letter-spacing: 0.5px; }
 }
 @media (max-width: 900px) {
-  .nav-menu { display: none; }
+  nav { grid-template-columns: auto 1fr; padding: 16px 20px; gap: 12px; }
+  .nav-menu { gap: 12px 8px; justify-content: flex-start; }
+  .nav-link { font-size: 8px; letter-spacing: 0.5px; }
+  .nav-right { grid-column: 1 / -1; justify-content: flex-end; margin-top: 4px; }
 }
 @media (max-width: 768px) {
   nav { padding: 16px 20px; }
@@ -525,8 +528,7 @@ window.addEventListener('unhandledrejection', function(e) {
 <nav>
   <a href="#" class="nav-logo">SATOSHi</a>
   <div class="nav-menu">
-    <a href="#" onclick="openPhotobook(); return false;" class="nav-link th-only" style="color: #00FF41;">[ เข้าสู่แกลเลอรี่ภาพ ]</a>
-    <a href="#" onclick="openPhotobook(); return false;" class="nav-link en-only" style="color: #00FF41;">[ ENTER PHOTOBOOK ]</a>
+    <a href="photobook.html" class="nav-link"><span class="th-only">หนังสือภาพ</span><span class="en-only">PHOTOBOOK</span></a>
     <a href="https://app.gitbook.com/invite/CC1p6uOmzX05YyLDPevJ/r3fCPzAmLSaX2XHCIdgr" target="_blank" class="nav-link th-only">ร่วมพัฒนาบทภาพยนตร์และสารคดี</a>
     <a href="https://app.gitbook.com/invite/CC1p6uOmzX05YyLDPevJ/r3fCPzAmLSaX2XHCIdgr" target="_blank" class="nav-link en-only">SCRIPT & DOC COLLAB</a>
     <a href="https://github.com/sootisooti/satoshi.film" target="_blank" class="nav-link th-only">ร่วมพัฒนาเว็ปไซต์ SATOSHi</a>
@@ -534,7 +536,7 @@ window.addEventListener('unhandledrejection', function(e) {
   </div>
   <div class="nav-right">
     <a href="#forum" style="font-family:'Space Mono',monospace;font-size:0.7rem;color:#00FF41;text-decoration:none;letter-spacing:0.15em;margin-right:16px;border:1px solid rgba(0,255,65,0.3);padding:6px 14px;"><span class="th-only">ชุมชน</span><span class="en-only">FORUM</span></a>
-    <a href="dialogue.html" style="font-family:'Space Mono',monospace;font-size:0.7rem;color:#F7931A;text-decoration:none;letter-spacing:0.15em;margin-right:16px;border:1px solid rgba(247,147,26,0.3);padding:6px 14px;">DIALOGUE</a>
+    <a href="dialogue.html" style="font-family:'Space Mono',monospace;font-size:0.7rem;color:#F7931A;text-decoration:none;letter-spacing:0.15em;margin-right:16px;border:1px solid rgba(247,147,26,0.3);padding:6px 14px;"><span class="th-only">บทภาพยนตร์</span><span class="en-only">DIALOGUE</span></a>
      <button class="nav-auth-btn" onclick="openAuth()"><span class="th-only">เข้าสู่ระบบ</span><span class="en-only">LOGIN</span></button>
     <button class="lang-toggle" onclick="toggleLang()"><span>EN / TH</span></button>
   </div>

--- a/photobook.html
+++ b/photobook.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PHOTOBOOK — SATOSHI</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Mono:wght@400;700&family=Noto+Serif+Thai:wght@400;700&family=Sarabun:wght@300;400&display=swap" rel="stylesheet">
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+html { background: #080806; }
+body {
+  font-family: 'Sarabun', sans-serif;
+  background: #080806;
+  color: #d4d0c8;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 20px;
+}
+
+.container {
+  text-align: center;
+  max-width: 600px;
+}
+
+.block-height {
+  font-family: 'Space Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 3px;
+  color: #666660;
+  margin-bottom: 60px;
+}
+
+.block-height a {
+  color: inherit;
+  text-decoration: none;
+  transition: color 0.3s;
+}
+
+.block-height a:hover {
+  color: #F7931A;
+}
+
+.block-num {
+  color: #F7931A;
+}
+
+.title-th {
+  font-family: 'Noto Serif Thai', serif;
+  font-size: clamp(28px, 6vw, 42px);
+  color: #d4d0c8;
+  margin-bottom: 16px;
+  letter-spacing: 0.2em;
+}
+
+.title-en {
+  font-family: 'Space Mono', monospace;
+  font-size: clamp(32px, 7vw, 52px);
+  color: #F7931A;
+  opacity: 0.6;
+  letter-spacing: 0.3em;
+  margin-bottom: 80px;
+}
+
+.back-link {
+  font-family: 'Space Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 2px;
+  color: #666660;
+  text-decoration: none;
+  border: 1px solid rgba(102,102,96,0.3);
+  padding: 12px 24px;
+  display: inline-block;
+  transition: all 0.3s;
+}
+
+.back-link:hover {
+  color: #F7931A;
+  border-color: #F7931A;
+}
+
+.error-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(8,8,6,0.98);
+  z-index: 99999;
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 40px;
+}
+
+.error-overlay.active { display: flex; }
+
+.error-content {
+  max-width: 600px;
+  text-align: center;
+}
+
+.error-title {
+  font-family: 'Space Mono', monospace;
+  font-size: 14px;
+  letter-spacing: 3px;
+  color: #F7931A;
+  margin-bottom: 16px;
+}
+
+.error-message {
+  font-family: 'Sarabun', sans-serif;
+  font-size: 13px;
+  color: #666660;
+  line-height: 1.8;
+  margin-bottom: 24px;
+}
+
+.error-close {
+  font-family: 'Space Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 2px;
+  color: #666660;
+  background: transparent;
+  border: 1px solid rgba(102,102,96,0.3);
+  padding: 8px 16px;
+  cursor: pointer;
+  transition: all 0.3s;
+}
+
+.error-close:hover {
+  color: #F7931A;
+  border-color: #F7931A;
+}
+
+@media (max-width: 640px) {
+  .title-th { font-size: 24px; }
+  .title-en { font-size: 28px; margin-bottom: 60px; }
+  .back-link { font-size: 10px; padding: 10px 20px; }
+}
+</style>
+</head>
+<body>
+
+<div class="container">
+  <div class="block-height">
+    BLOCK <a href="https://mempool.space/" target="_blank" rel="noopener"><span class="block-num">———</span></a>
+  </div>
+
+  <h1 class="title-th">หนังสือภาพ — เร็วๆ นี้</h1>
+  <h2 class="title-en">PHOTOBOOK — COMING SOON</h2>
+
+  <a href="index.html" class="back-link">← กลับหน้าหลัก / BACK HOME</a>
+</div>
+
+<div class="error-overlay" id="errorOverlay">
+  <div class="error-content">
+    <div class="error-title">ERROR</div>
+    <div class="error-message" id="errorMessage"></div>
+    <button class="error-close" onclick="document.getElementById('errorOverlay').classList.remove('active')">CLOSE</button>
+  </div>
+</div>
+
+<script>
+// Block height counter
+fetch('https://mempool.space/api/blocks/tip/height')
+  .then(r => r.json())
+  .then(h => {
+    const nums = document.querySelectorAll('.block-num');
+    nums.forEach(n => n.textContent = h.toLocaleString());
+  })
+  .catch(e => console.error('Block height fetch failed:', e));
+
+// Global error handler
+window.addEventListener('error', function(e) {
+  document.getElementById('errorMessage').textContent = e.message || 'An unexpected error occurred';
+  document.getElementById('errorOverlay').classList.add('active');
+});
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Fixed two nav bugs and created photobook placeholder as requested in #16.

## Bugs Fixed

1. **Photobook link overflow on Safari mobile**: Renamed from "เข้าสู่แกลเลอรี่ภาพ" (too long) to bilingual format "หนังสือภาพ/PHOTOBOOK". Removed onclick handler and now links directly to photobook.html.
2. **DIALOGUE missing Thai translation**: Added Thai span "บทภาพยนตร์" alongside English "DIALOGUE".

## Mobile Strategy

Chose **allow nav to wrap to multiple rows**:
- Nav-menu already had `flex-wrap: wrap` enabled
- Less disruptive than hamburger menu
- At 900px and below: removed `display: none`, reduced font-size, adjusted gaps

## Photobook Placeholder

Created minimal photobook.html (< 5KB):
- Inherits visual DNA: #080806 bg, #F7931A accent, matching fonts
- Bilingual coming soon message
- Block height counter
- Back link to index.html
- Error overlay pattern

## Test Plan

**At 375px:**
- All nav items visible or wrapped cleanly
- Photobook link displays "หนังสือภาพ/PHOTOBOOK"
- DIALOGUE link displays "บทภาพยนตร์/DIALOGUE"
- Nav wraps without overflow
- Photobook placeholder loads correctly

**At desktop:**
- Nav remains on single row
- All bilingual pairs display simultaneously

Closes #16

---

Generated with [Claude Code](https://claude.ai/code)