### PR TITLE
fix: prevent querySelector error with empty hash anchors

### DIFF
--- a/index.html
+++ b/index.html
@@ -2348,10 +2348,13 @@ if (friedcatModal) {
 
 document.querySelectorAll('a[href^="#"]').forEach(a => {
   a.addEventListener('click', (e) => {
-    const target = document.querySelector(a.getAttribute('href'));
-    if (target) {
-      e.preventDefault();
-      target.scrollIntoView({ behavior: 'smooth' });
+    const href = a.getAttribute('href');
+    if (href && href.length > 1) {
+      const target = document.querySelector(href);
+      if (target) {
+        e.preventDefault();
+        target.scrollIntoView({ behavior: 'smooth' });
+      }
     }
   });
 });


### PR DESCRIPTION
## Summary

**Root cause**: Line 2351 in index.html — smooth-scroll handler passed `href="#"` directly to `querySelector()`, which is invalid.

**Fix**: Added validation `if (href && href.length > 1)` before calling querySelector.

**Why the banner still worked despite this error**: The banner dismissal logic uses localStorage and direct event handlers that don't depend on the smooth-scroll code path.

## Test plan

- [ ] Refresh page → no red error overlay with querySelector error
- [ ] Click valid hash links (e.g., `#about`, `#forum`) → smooth scroll still works
- [ ] Banner shows on first load → can be dismissed → dismissal persists

Resolves #24

🤖 Generated with [Claude Code](https://claude.ai/code)