### PR TITLE
fix: robust JSON extraction in callClaude to handle markdown fences

### DIFF
--- a/scripts/curate-forum.js
+++ b/scripts/curate-forum.js
@@ -226,6 +226,26 @@ ${candidateLines}
 `;
 }
 
+function extractJson(responseText) {
+  // Extract content from a complete markdown code fence (handles preamble text)
+  const fenceMatch = responseText.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fenceMatch) return fenceMatch[1].trim();
+
+  // Strip incomplete leading/trailing fences
+  const cleaned = responseText
+    .replace(/^```json\s*/i, "")
+    .replace(/^```\s*/i, "")
+    .replace(/```\s*$/i, "")
+    .trim();
+
+  // Last resort: find outermost JSON object by brace boundaries (handles preamble)
+  const start = cleaned.indexOf("{");
+  const end = cleaned.lastIndexOf("}");
+  if (start !== -1 && end > start) return cleaned.slice(start, end + 1);
+
+  return cleaned;
+}
+
 async function callClaude(prompt) {
   log(`Calling Claude API (${MODEL}, max_tokens=${MAX_TOKENS})`);
   const res = await fetch("https://api.anthropic.com/v1/messages", {
@@ -248,13 +268,12 @@ async function callClaude(prompt) {
   }
 
   const data = await res.json();
-  return data.content
+  const responseText = data.content
     .filter((b) => b.type === "text")
     .map((b) => b.text)
-    .join("\n")
-    .replace(/^```json\s*/m, "")
-    .replace(/```\s*$/m, "")
-    .trim();
+    .join("\n");
+
+  return extractJson(responseText);
 }
 
 (async () => {


### PR DESCRIPTION
Replaces inline regex strips (which used /m flag and couldn't handle
preamble text) with an extractJson() helper that tries three strategies:
1. Extract from a complete ```json ... ``` fence (handles preamble)
2. Strip incomplete leading/trailing fence markers
3. Find outermost JSON object by { } boundaries as last resort

Fixes "Failed to parse Claude response as JSON ... position 1218" error
from the 2026-04-27 run where Claude prepended a markdown fence or
preamble to the JSON output.

https://claude.ai/code/session_014BPSuYo9Ut1PrxxMwMcfjW