### PR TITLE
fix(curate-forum): archive previous week, not current, to prevent dropdown duplicate

### DIFF
--- a/scripts/curate-forum.js
+++ b/scripts/curate-forum.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * curate-forum.js (v3 - archive support)
+ * curate-forum.js (v4 - correct archive semantics)
  *
  * Weekly forum curation script for SATOSHI.FILM.
  *
@@ -9,11 +9,16 @@
  *   We scrape the standard board HTML pages instead, which are stable
  *   (the forum runs SMF 1.1 with custom theme - unchanged for years).
  *
- * Archive behavior (v3):
- *   Each run writes TWO files:
- *   1. forum-archive/YYYY-W##.json (permanent snapshot)
- *   2. forum-daily.json (latest week, overwritten)
- *   Also maintains forum-archive/index.json manifest for week picker.
+ * Archive behavior (v4):
+ *   On each run, the existing forum-daily.json (previous week's curation)
+ *   is snapshotted to forum-archive/<prev-iso-week>.json BEFORE
+ *   forum-daily.json is overwritten with this week's curation. The
+ *   current week lives only in forum-daily.json (served as "CURRENT" in
+ *   the week picker); forum-archive/index.json lists past weeks only.
+ *
+ *   v3 wrote the current week to both files on the same run, producing
+ *   byte-identical files and a manifest entry that duplicated CURRENT
+ *   in the dropdown (issue #29).
  */
 
 import { writeFile, mkdir, readFile } from "node:fs/promises";
@@ -348,13 +353,34 @@ async function callClaude(prompt) {
     // Ensure archive directory exists
     await mkdir(archiveDir, { recursive: true });
 
-    // 1. Write archive snapshot FIRST (before overwriting forum-daily.json)
-    const archiveFileName = `${isoWeek}.json`;
-    const archivePath = resolve(archiveDir, archiveFileName);
-    await writeFile(archivePath, JSON.stringify(parsed, null, 2) + "\n");
-    log(`Wrote archive: forum-archive/${archiveFileName}`);
+    const outPath = resolve(repoRoot, OUT_FILE);
 
-    // 2. Update archive manifest (index.json)
+    // 1. Read existing forum-daily.json to capture the PREVIOUS week's data
+    //    before we overwrite it. That snapshot is what belongs in the archive.
+    let previousWeekData = null;
+    try {
+      const existingDailyRaw = await readFile(outPath, "utf-8");
+      const existingDaily = JSON.parse(existingDailyRaw);
+      if (existingDaily.iso_week && existingDaily.iso_week !== isoWeek) {
+        previousWeekData = existingDaily;
+      } else if (!existingDaily.iso_week) {
+        log("Existing forum-daily.json has no iso_week field, skipping archive");
+      } else {
+        log(`Existing forum-daily.json is same week (${isoWeek}), skipping archive`);
+      }
+    } catch (err) {
+      log("No existing forum-daily.json to archive (first run?)");
+    }
+
+    // 2. Snapshot the previous week to forum-archive/<prev-iso-week>.json
+    if (previousWeekData) {
+      const prevWeek = previousWeekData.iso_week;
+      const prevArchivePath = resolve(archiveDir, `${prevWeek}.json`);
+      await writeFile(prevArchivePath, JSON.stringify(previousWeekData, null, 2) + "\n");
+      log(`Archived previous week: forum-archive/${prevWeek}.json`);
+    }
+
+    // 3. Update archive manifest (index.json)
     const manifestPath = resolve(archiveDir, "index.json");
     let manifest = { weeks: [] };
     try {
@@ -364,19 +390,30 @@ async function callClaude(prompt) {
       log("No existing manifest, creating new one");
     }
 
-    // Add this week if not already present
-    if (!manifest.weeks.find(w => w.iso_week === isoWeek)) {
-      manifest.weeks.unshift({
-        iso_week: isoWeek,
-        curated_date: parsed.curated_date,
-        topic_count: parsed.topics.length
-      });
-      log(`Added ${isoWeek} to manifest`);
-    } else {
-      log(`${isoWeek} already in manifest, updating entry`);
-      const existing = manifest.weeks.find(w => w.iso_week === isoWeek);
-      existing.curated_date = parsed.curated_date;
-      existing.topic_count = parsed.topics.length;
+    // Current week lives in forum-daily.json (CURRENT option), never the archive.
+    // Drop any stale entry for the current week from older buggy runs.
+    const beforeLen = manifest.weeks.length;
+    manifest.weeks = manifest.weeks.filter(w => w.iso_week !== isoWeek);
+    if (manifest.weeks.length !== beforeLen) {
+      log(`Removed stale current-week entry (${isoWeek}) from manifest`);
+    }
+
+    // Record the previous week we just archived
+    if (previousWeekData) {
+      const prevWeek = previousWeekData.iso_week;
+      const existing = manifest.weeks.find(w => w.iso_week === prevWeek);
+      if (existing) {
+        existing.curated_date = previousWeekData.curated_date;
+        existing.topic_count = previousWeekData.topics?.length || 0;
+        log(`Updated ${prevWeek} in manifest`);
+      } else {
+        manifest.weeks.unshift({
+          iso_week: prevWeek,
+          curated_date: previousWeekData.curated_date,
+          topic_count: previousWeekData.topics?.length || 0,
+        });
+        log(`Added ${prevWeek} to manifest`);
+      }
     }
 
     // Keep manifest sorted by ISO week (newest first)
@@ -385,8 +422,7 @@ async function callClaude(prompt) {
     await writeFile(manifestPath, JSON.stringify(manifest, null, 2) + "\n");
     log("Updated manifest: forum-archive/index.json");
 
-    // 3. Write forum-daily.json (overwrites previous week)
-    const outPath = resolve(repoRoot, OUT_FILE);
+    // 4. Write forum-daily.json (overwrites previous week's content)
     await writeFile(outPath, JSON.stringify(parsed, null, 2) + "\n");
     log(`Wrote ${parsed.topics.length} topics to ${OUT_FILE}`);
     log("Done.");


### PR DESCRIPTION
The v3 archive logic wrote the same parsed object to both forum-daily.json
and forum-archive/<current-iso-week>.json on the same run, producing
byte-identical files and a manifest entry that duplicated the CURRENT
dropdown option. v4 reads the existing forum-daily.json first and
snapshots the previous week before overwriting. The current week now
lives only in forum-daily.json. Refs #29.