### PR TITLE
feat: photobook contact sheet + index cover captions

### DIFF
--- a/index.html
+++ b/index.html
@@ -467,17 +467,19 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
   .preprod-banner { padding: 8px 12px; }
 }
 
-.poster-cover { position: fixed; inset: 0; z-index: 100000; background: #080806; display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 48px; gap: 24px; opacity: 1; transition: opacity 0.6s ease-out; }
+.poster-cover { position: fixed; inset: 0; z-index: 100000; background: #080806; display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 48px; gap: 28px; opacity: 1; transition: opacity 0.6s ease-out; overflow-y: auto; }
 .poster-cover.dismissed { opacity: 0; pointer-events: none; }
-.poster-cover-image { max-width: min(90vw, 720px); max-height: 82vh; object-fit: contain; box-shadow: 0 24px 80px rgba(0,0,0,0.7); opacity: 0; transition: opacity 0.8s ease-out; }
+.poster-cover-image { max-width: min(90vw, 560px); max-height: 60vh; object-fit: contain; box-shadow: 0 24px 80px rgba(0,0,0,0.7); opacity: 0; transition: opacity 0.8s ease-out; }
 .poster-cover-image.loaded { opacity: 1; }
+.poster-cover-caption { font-family: 'Tahoma', Arial, sans-serif; font-size: 2.1cm; line-height: 1.25; color: #d4d0c8; text-align: center; max-width: 92vw; letter-spacing: 0.01em; }
 .poster-cover-meta { font-family: 'Space Mono', monospace; font-size: 9px; letter-spacing: 3px; color: #666660; }
 .poster-cover-meta span { color: #F7931A; }
-.poster-cover-close { position: absolute; top: 24px; right: 24px; width: 44px; height: 44px; background: transparent; border: 1px solid rgba(255,255,255,0.18); color: #d4d0c8; font-family: 'Space Mono', monospace; font-size: 22px; line-height: 1; cursor: none; display: flex; align-items: center; justify-content: center; transition: all 0.2s; }
+.poster-cover-close { position: absolute; top: 24px; right: 24px; width: 44px; height: 44px; background: transparent; border: 1px solid rgba(255,255,255,0.18); color: #d4d0c8; font-family: 'Space Mono', monospace; font-size: 22px; line-height: 1; cursor: none; display: flex; align-items: center; justify-content: center; transition: all 0.2s; z-index: 1; }
 .poster-cover-close:hover { border-color: #F7931A; color: #F7931A; }
 @media (max-width: 768px) {
-  .poster-cover { padding: 20px; gap: 16px; }
-  .poster-cover-image { max-height: 78vh; }
+  .poster-cover { padding: 20px; gap: 18px; }
+  .poster-cover-image { max-height: 45vh; }
+  .poster-cover-caption { font-size: clamp(18px, 5vw, 2.1cm); }
   .poster-cover-meta { font-size: 8px; letter-spacing: 2px; }
   .poster-cover-close { top: 12px; right: 12px; }
 }
@@ -487,20 +489,23 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
 <div id="posterCover" class="poster-cover" role="dialog" aria-label="SATOSHI.FILM cover">
   <button id="posterCoverClose" class="poster-cover-close" aria-label="Close cover">×</button>
   <img id="posterCoverImg" class="poster-cover-image" src="" alt="SATOSHI.FILM">
+  <div id="posterCoverCaption" class="poster-cover-caption"></div>
   <div class="poster-cover-meta">SATOSHI<span>.</span>FILM · <span id="posterCoverNum">01</span> / 03 · ESC TO ENTER</div>
 </div>
 <script>
 (function() {
   const POSTERS = [
-    'assets/posters/poster-01.jpg',
-    'assets/posters/poster-02.jpg',
-    'assets/posters/poster-03.jpg'
+    { img: 'assets/posters/poster-01.jpg', caption: 'เราเปลี่ยนพ่อแม่ไม่ได้ แต่เราเปลี่ยนตัวเองได้ 🌱' },
+    { img: 'assets/posters/poster-02.jpg', caption: 'เราเปลี่ยนลูกไม่ได้ แต่เราเปลี่ยนตัวเองได้ 🥛' },
+    { img: 'assets/posters/poster-03.jpg', caption: 'เราเปลี่ยนรัฐบาลไม่ได้ แต่เราเปลี่ยนตัวเองได้ 🔐' }
   ];
   const idx = Math.floor(Math.random() * POSTERS.length);
+  const pick = POSTERS[idx];
   const overlay = document.getElementById('posterCover');
   const img = document.getElementById('posterCoverImg');
   img.addEventListener('load', () => img.classList.add('loaded'));
-  img.src = POSTERS[idx];
+  img.src = pick.img;
+  document.getElementById('posterCoverCaption').textContent = pick.caption;
   document.getElementById('posterCoverNum').textContent = String(idx + 1).padStart(2, '0');
   document.body.style.overflow = 'hidden';
   const close = () => {

--- a/photobook.html
+++ b/photobook.html
@@ -15,16 +15,13 @@ body {
   background: #080806;
   color: #d4d0c8;
   min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 40px 20px;
+  padding: 80px 20px 60px;
 }
 
 .container {
   text-align: center;
-  max-width: 600px;
+  max-width: 1200px;
+  margin: 0 auto;
 }
 
 .block-height {
@@ -63,7 +60,112 @@ body {
   color: #F7931A;
   opacity: 0.6;
   letter-spacing: 0.3em;
+  margin-bottom: 24px;
+}
+
+.photobook-meta {
+  font-family: 'Space Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 3px;
+  color: #666660;
+  margin-bottom: 60px;
+}
+.photobook-meta span { color: #00FF41; }
+
+.photobook-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
   margin-bottom: 80px;
+}
+
+.photobook-frame {
+  position: relative;
+  background: transparent;
+  border: 1px solid rgba(255,255,255,0.08);
+  padding: 12px 12px 36px;
+  cursor: pointer;
+  transition: all 0.3s;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  font-family: inherit;
+  text-align: left;
+}
+.photobook-frame:hover {
+  border-color: rgba(247,147,26,0.4);
+  background: rgba(247,147,26,0.02);
+}
+.photobook-frame img {
+  width: 100%;
+  height: auto;
+  display: block;
+  aspect-ratio: 2 / 3;
+  object-fit: cover;
+  filter: grayscale(0.15) brightness(0.92);
+  transition: filter 0.3s;
+}
+.photobook-frame:hover img {
+  filter: grayscale(0) brightness(1);
+}
+.photobook-frame-num {
+  position: absolute;
+  bottom: 12px;
+  left: 12px;
+  font-family: 'Space Mono', monospace;
+  font-size: 9px;
+  letter-spacing: 2px;
+  color: #666660;
+}
+.photobook-frame:hover .photobook-frame-num { color: #F7931A; }
+
+@media (max-width: 900px) {
+  .photobook-grid { grid-template-columns: repeat(2, 1fr); gap: 16px; }
+}
+@media (max-width: 560px) {
+  .photobook-grid { grid-template-columns: 1fr; gap: 16px; }
+}
+
+.photobook-lightbox {
+  position: fixed; inset: 0; z-index: 100000;
+  background: #080806;
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 48px;
+  gap: 20px;
+}
+.photobook-lightbox.active { display: flex; }
+.photobook-lightbox img {
+  max-width: min(90vw, 720px);
+  max-height: 82vh;
+  object-fit: contain;
+  box-shadow: 0 24px 80px rgba(0,0,0,0.7);
+}
+.photobook-lightbox-meta {
+  font-family: 'Space Mono', monospace;
+  font-size: 9px;
+  letter-spacing: 3px;
+  color: #666660;
+}
+.photobook-lightbox-meta span { color: #F7931A; }
+.photobook-lightbox-close {
+  position: absolute; top: 24px; right: 24px;
+  width: 44px; height: 44px;
+  background: transparent;
+  border: 1px solid rgba(255,255,255,0.18);
+  color: #d4d0c8;
+  font-family: 'Space Mono', monospace;
+  font-size: 22px; line-height: 1;
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  transition: all 0.2s;
+}
+.photobook-lightbox-close:hover { border-color: #F7931A; color: #F7931A; }
+@media (max-width: 768px) {
+  .photobook-lightbox { padding: 20px; }
+  .photobook-lightbox-close { top: 12px; right: 12px; }
 }
 
 .back-link {
@@ -223,10 +325,32 @@ body {
     BLOCK <a href="https://mempool.space/" target="_blank" rel="noopener"><span class="block-num">———</span></a>
   </div>
 
-  <h1 class="title-th">หนังสือภาพ — เร็วๆ นี้</h1>
-  <h2 class="title-en">PHOTOBOOK — COMING SOON</h2>
+  <h1 class="title-th">หนังสือภาพ</h1>
+  <h2 class="title-en">PHOTOBOOK</h2>
+  <div class="photobook-meta">FIRST FRAMES · <span>03</span> · WORK IN PROGRESS</div>
+
+  <div class="photobook-grid">
+    <button class="photobook-frame" data-img="assets/posters/poster-01.jpg" data-num="01" aria-label="Open frame 01">
+      <img src="assets/posters/poster-01.jpg" alt="Frame 01" loading="lazy">
+      <div class="photobook-frame-num">FRAME 01 / 03</div>
+    </button>
+    <button class="photobook-frame" data-img="assets/posters/poster-02.jpg" data-num="02" aria-label="Open frame 02">
+      <img src="assets/posters/poster-02.jpg" alt="Frame 02" loading="lazy">
+      <div class="photobook-frame-num">FRAME 02 / 03</div>
+    </button>
+    <button class="photobook-frame" data-img="assets/posters/poster-03.jpg" data-num="03" aria-label="Open frame 03">
+      <img src="assets/posters/poster-03.jpg" alt="Frame 03" loading="lazy">
+      <div class="photobook-frame-num">FRAME 03 / 03</div>
+    </button>
+  </div>
 
   <a href="index.html" class="back-link">← กลับหน้าหลัก / BACK HOME</a>
+</div>
+
+<div class="photobook-lightbox" id="photobookLightbox" role="dialog" aria-label="Photobook frame">
+  <button class="photobook-lightbox-close" id="photobookLightboxClose" aria-label="Close">×</button>
+  <img id="photobookLightboxImg" src="" alt="">
+  <div class="photobook-lightbox-meta">FRAME <span id="photobookLightboxNum">01</span> / 03 · ESC TO CLOSE</div>
 </div>
 
 <div class="error-overlay" id="errorOverlay">
@@ -252,6 +376,39 @@ window.addEventListener('error', function(e) {
   document.getElementById('errorMessage').textContent = e.message || 'An unexpected error occurred';
   document.getElementById('errorOverlay').classList.add('active');
 });
+
+// Photobook lightbox
+(function() {
+  const lightbox = document.getElementById('photobookLightbox');
+  const lightboxImg = document.getElementById('photobookLightboxImg');
+  const lightboxNum = document.getElementById('photobookLightboxNum');
+  const lightboxClose = document.getElementById('photobookLightboxClose');
+  if (!lightbox) return;
+
+  const open = (src, num, alt) => {
+    lightboxImg.src = src;
+    lightboxImg.alt = alt;
+    lightboxNum.textContent = num;
+    lightbox.classList.add('active');
+    document.body.style.overflow = 'hidden';
+  };
+  const close = () => {
+    lightbox.classList.remove('active');
+    document.body.style.overflow = '';
+    lightboxImg.src = '';
+  };
+
+  document.querySelectorAll('.photobook-frame').forEach(frame => {
+    frame.addEventListener('click', () => {
+      open(frame.dataset.img, frame.dataset.num, frame.querySelector('img').alt);
+    });
+  });
+  lightboxClose.addEventListener('click', close);
+  lightbox.addEventListener('click', (e) => { if (e.target === lightbox) close(); });
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && lightbox.classList.contains('active')) close();
+  });
+})();
 </script>
 
 <script>


### PR DESCRIPTION
## Summary

Two related changes for the post-merge follow-up:

1. **Photobook contact sheet** (`photobook.html`): replaced the "Coming Soon" placeholder with a real first-frames gallery using the 3 posters in `assets/posters/`. Click any frame to open a fullscreen lightbox (× / ESC / backdrop to close). 3-up desktop grid, 2-up tablet, 1-up mobile.
2. **Index cover captions** (`index.html`): paired each random poster with a Tahoma 2.1cm caption per design direction.
   - 01 — `เราเปลี่ยนพ่อแม่ไม่ได้ แต่เราเปลี่ยนตัวเองได้ 🌱`
   - 02 — `เราเปลี่ยนลูกไม่ได้ แต่เราเปลี่ยนตัวเองได้ 🥛`
   - 03 — `เราเปลี่ยนรัฐบาลไม่ได้ แต่เราเปลี่ยนตัวเองได้ 🔐`

## Files changed

- `photobook.html` — gallery + lightbox (+165 / -8)
- `index.html` — captions paired to random poster (+14 / -9)

## Notes

- Tahoma is system sans, not in the project's Space Mono / Noto Serif Thai / Sarabun stack — but spec'd explicitly for this caption.
- Mobile uses `clamp(18px, 5vw, 2.1cm)` so the caption stays readable below 768px.
- BUNDLES, Verify modal, easter eggs, and the Cypherpunk Score are untouched.

## Test plan

- [ ] Refresh `/` repeatedly — random poster + matching caption appear, ESC/× dismisses
- [ ] Visit `/photobook.html` — 3 frames render, click each, lightbox opens, ESC closes
- [ ] Mobile (375px) — caption wraps without overflow, photobook collapses to 1 column

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvN2pieKMgc6rURksuFAVb)_