### PR TITLE
style(cover) + feat(i18n): halve caption, rename to SATOSHI.MEDIA, add cover lang toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -471,7 +471,7 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
 .poster-cover.dismissed { opacity: 0; pointer-events: none; }
 .poster-cover-image { max-width: min(90vw, 560px); max-height: 60vh; object-fit: contain; box-shadow: 0 24px 80px rgba(0,0,0,0.7); opacity: 0; transition: opacity 0.8s ease-out; }
 .poster-cover-image.loaded { opacity: 1; }
-.poster-cover-caption { font-family: 'Tahoma', Arial, sans-serif; font-size: 2.1cm; line-height: 1.25; color: #d4d0c8; text-align: center; max-width: 92vw; letter-spacing: 0.01em; }
+.poster-cover-caption { font-family: 'Tahoma', Arial, sans-serif; font-size: 1.05cm; line-height: 1.3; color: #d4d0c8; text-align: center; max-width: 92vw; letter-spacing: 0.01em; }
 .poster-cover-meta { font-family: 'Space Mono', monospace; font-size: 9px; letter-spacing: 3px; color: #666660; }
 .poster-cover-meta span { color: #F7931A; }
 .poster-cover-close { position: absolute; top: 24px; right: 24px; width: 44px; height: 44px; background: transparent; border: 1px solid rgba(255,255,255,0.18); color: #d4d0c8; font-family: 'Space Mono', monospace; font-size: 22px; line-height: 1; cursor: none; display: flex; align-items: center; justify-content: center; transition: all 0.2s; z-index: 1; }
@@ -479,7 +479,7 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
 @media (max-width: 768px) {
   .poster-cover { padding: 20px; gap: 18px; }
   .poster-cover-image { max-height: 45vh; }
-  .poster-cover-caption { font-size: clamp(18px, 5vw, 2.1cm); }
+  .poster-cover-caption { font-size: clamp(14px, 3vw, 1.05cm); }
   .poster-cover-meta { font-size: 8px; letter-spacing: 2px; }
   .poster-cover-close { top: 12px; right: 12px; }
 }


### PR DESCRIPTION
## Summary

Bundle of cover/branding follow-ups on top of PR #32:

1. **Halve cover caption** to 1.05cm desktop / `clamp(14px, 3vw, 1.05cm)` mobile (was 2.1cm and felt too large).
2. **Rename photobook → SATOSHI.MEDIA**:
   - TH title: `หนังสือภาพ` → `หนัง / สื่อ / ภาพ`
   - EN title: `PHOTOBOOK` → `SATOSHI.MEDIA`
   - Updated in `photobook.html` (page title + h1/h2) and `index.html` nav link.
3. **EN translations + language toggle on the cover**:
   - Added EN versions of the 3 captions.
   - Cover now has an `EN | TH` toggle button (top-left, mirrors the × close in top-right) that calls the existing `toggleLang()` so the cover follows the global language state.
   - Captions use the existing `.th-only` / `.en-only` span pattern.

## Files changed

- `index.html` — caption size + EN copy + lang toggle on cover + nav link
- `photobook.html` — page title, h1/h2 rename

## Test plan

- [ ] Refresh `/` — caption visibly half the previous size
- [ ] Click `EN | TH` on cover — caption swaps language; site behind also follows
- [ ] Dismiss cover, scroll to nav — link reads `หนัง / สื่อ / ภาพ` (TH) or `SATOSHI.MEDIA` (EN)
- [ ] `/photobook.html` — h1/h2 show new names; gallery still works