### PR TITLE
feat(i18n): rename to SATOSHI.MEDIA + add EN cover captions with TH/EN toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -476,28 +476,35 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
 .poster-cover-meta span { color: #F7931A; }
 .poster-cover-close { position: absolute; top: 24px; right: 24px; width: 44px; height: 44px; background: transparent; border: 1px solid rgba(255,255,255,0.18); color: #d4d0c8; font-family: 'Space Mono', monospace; font-size: 22px; line-height: 1; cursor: none; display: flex; align-items: center; justify-content: center; transition: all 0.2s; z-index: 1; }
 .poster-cover-close:hover { border-color: #F7931A; color: #F7931A; }
+.poster-cover-lang { position: absolute; top: 24px; left: 24px; height: 44px; padding: 0 14px; background: transparent; border: 1px solid rgba(255,255,255,0.18); color: #d4d0c8; font-family: 'Space Mono', monospace; font-size: 11px; letter-spacing: 2px; line-height: 1; cursor: none; display: flex; align-items: center; justify-content: center; transition: all 0.2s; z-index: 1; }
+.poster-cover-lang:hover { border-color: #F7931A; color: #F7931A; }
 @media (max-width: 768px) {
   .poster-cover { padding: 20px; gap: 18px; }
   .poster-cover-image { max-height: 45vh; }
   .poster-cover-caption { font-size: clamp(14px, 3vw, 1.05cm); }
   .poster-cover-meta { font-size: 8px; letter-spacing: 2px; }
   .poster-cover-close { top: 12px; right: 12px; }
+  .poster-cover-lang { top: 12px; left: 12px; height: 36px; padding: 0 10px; font-size: 10px; }
 }
 </style>
 </head>
 <body class="lang-th">
 <div id="posterCover" class="poster-cover" role="dialog" aria-label="SATOSHI.FILM cover">
+  <button id="posterCoverLang" class="poster-cover-lang" aria-label="Toggle language">EN | TH</button>
   <button id="posterCoverClose" class="poster-cover-close" aria-label="Close cover">×</button>
   <img id="posterCoverImg" class="poster-cover-image" src="" alt="SATOSHI.FILM">
-  <div id="posterCoverCaption" class="poster-cover-caption"></div>
+  <div id="posterCoverCaption" class="poster-cover-caption">
+    <span class="th-only" id="posterCoverCaptionTh"></span>
+    <span class="en-only" id="posterCoverCaptionEn"></span>
+  </div>
   <div class="poster-cover-meta">SATOSHI<span>.</span>FILM · <span id="posterCoverNum">01</span> / 03 · ESC TO ENTER</div>
 </div>
 <script>
 (function() {
   const POSTERS = [
-    { img: 'assets/posters/poster-01.jpg', caption: 'เราเปลี่ยนพ่อแม่ไม่ได้ แต่เราเปลี่ยนตัวเองได้ 🌱' },
-    { img: 'assets/posters/poster-02.jpg', caption: 'เราเปลี่ยนลูกไม่ได้ แต่เราเปลี่ยนตัวเองได้ 🥛' },
-    { img: 'assets/posters/poster-03.jpg', caption: 'เราเปลี่ยนรัฐบาลไม่ได้ แต่เราเปลี่ยนตัวเองได้ 🔐' }
+    { img: 'assets/posters/poster-01.jpg', th: 'เราเปลี่ยนพ่อแม่ไม่ได้ แต่เราเปลี่ยนตัวเองได้ 🌱', en: "We can't change our parents, but we can change ourselves. 🌱" },
+    { img: 'assets/posters/poster-02.jpg', th: 'เราเปลี่ยนลูกไม่ได้ แต่เราเปลี่ยนตัวเองได้ 🥛', en: "We can't change our children, but we can change ourselves. 🥛" },
+    { img: 'assets/posters/poster-03.jpg', th: 'เราเปลี่ยนรัฐบาลไม่ได้ แต่เราเปลี่ยนตัวเองได้ 🔐', en: "We can't change the government, but we can change ourselves. 🔐" }
   ];
   const idx = Math.floor(Math.random() * POSTERS.length);
   const pick = POSTERS[idx];
@@ -505,7 +512,8 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
   const img = document.getElementById('posterCoverImg');
   img.addEventListener('load', () => img.classList.add('loaded'));
   img.src = pick.img;
-  document.getElementById('posterCoverCaption').textContent = pick.caption;
+  document.getElementById('posterCoverCaptionTh').textContent = pick.th;
+  document.getElementById('posterCoverCaptionEn').textContent = pick.en;
   document.getElementById('posterCoverNum').textContent = String(idx + 1).padStart(2, '0');
   document.body.style.overflow = 'hidden';
   const close = () => {
@@ -516,6 +524,9 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
   };
   const onKey = (e) => { if (e.key === 'Escape') close(); };
   document.getElementById('posterCoverClose').addEventListener('click', close);
+  document.getElementById('posterCoverLang').addEventListener('click', () => {
+    if (typeof window.toggleLang === 'function') window.toggleLang();
+  });
   document.addEventListener('keydown', onKey);
 })();
 </script>
@@ -719,7 +730,7 @@ function dismissPreProdBanner() {
 <nav>
   <a href="#" class="nav-logo">SATOSHi</a>
   <div class="nav-menu">
-    <a href="photobook.html" class="nav-link"><span class="th-only">หนังสือภาพ</span><span class="en-only">PHOTOBOOK</span></a>
+    <a href="photobook.html" class="nav-link"><span class="th-only">หนัง / สื่อ / ภาพ</span><span class="en-only">SATOSHI.MEDIA</span></a>
     <a href="https://app.gitbook.com/invite/CC1p6uOmzX05YyLDPevJ/r3fCPzAmLSaX2XHCIdgr" target="_blank" class="nav-link th-only">ร่วมพัฒนาบทภาพยนตร์และสารคดี</a>
     <a href="https://app.gitbook.com/invite/CC1p6uOmzX05YyLDPevJ/r3fCPzAmLSaX2XHCIdgr" target="_blank" class="nav-link en-only">SCRIPT & DOC COLLAB</a>
     <a href="https://github.com/sootisooti/satoshi.film" target="_blank" class="nav-link th-only">ร่วมพัฒนาเว็ปไซต์ SATOSHi</a>

--- a/photobook.html
+++ b/photobook.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>PHOTOBOOK — SATOSHI</title>
+<title>SATOSHI.MEDIA — SATOSHI</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Space+Mono:wght@400;700&family=Noto+Serif+Thai:wght@400;700&family=Sarabun:wght@300;400&display=swap" rel="stylesheet">
@@ -325,8 +325,8 @@ body {
     BLOCK <a href="https://mempool.space/" target="_blank" rel="noopener"><span class="block-num">———</span></a>
   </div>
 
-  <h1 class="title-th">หนังสือภาพ</h1>
-  <h2 class="title-en">PHOTOBOOK</h2>
+  <h1 class="title-th">หนัง / สื่อ / ภาพ</h1>
+  <h2 class="title-en">SATOSHI.MEDIA</h2>
   <div class="photobook-meta">FIRST FRAMES · <span>03</span> · WORK IN PROGRESS</div>
 
   <div class="photobook-grid">


### PR DESCRIPTION
## Summary

Follow-up — this commit was pushed after PR #33 had already merged, so it didn't get included.

1. **Rename photobook → SATOSHI.MEDIA**
   - TH title: `หนังสือภาพ` → `หนัง / สื่อ / ภาพ`
   - EN title: `PHOTOBOOK` → `SATOSHI.MEDIA`
   - `photobook.html` page title + h1/h2; `index.html` nav link
2. **EN cover captions + lang toggle**
   - Added EN translations for the 3 cover captions
   - New `EN | TH` button (top-left of cover, mirrors × close) wired to existing `toggleLang()` so cover honors global language state
   - Captions use the standard `.th-only` / `.en-only` span pattern

## Files changed

- `index.html` — EN captions, lang toggle button, nav link rename
- `photobook.html` — page title, h1/h2 rename

## Test plan

- [ ] Refresh `/` — captions render in current language; click `EN | TH` swaps language across cover and site
- [ ] Dismiss cover → nav link reads `หนัง / สื่อ / ภาพ` (TH) or `SATOSHI.MEDIA` (EN)
- [ ] `/photobook.html` — new title visible; gallery still works

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvN2pieKMgc6rURksuFAVb)_