### PR TITLE
style: swap photobook frames 02/03 + shrink EN cover caption

### DIFF
--- a/index.html
+++ b/index.html
@@ -472,6 +472,7 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
 .poster-cover-image { max-width: min(90vw, 560px); max-height: 60vh; object-fit: contain; box-shadow: 0 24px 80px rgba(0,0,0,0.7); opacity: 0; transition: opacity 0.8s ease-out; }
 .poster-cover-image.loaded { opacity: 1; }
 .poster-cover-caption { font-family: 'Tahoma', Arial, sans-serif; font-size: 1.05cm; line-height: 1.3; color: #d4d0c8; text-align: center; max-width: 92vw; letter-spacing: 0.01em; }
+.poster-cover-caption .en-only { font-size: 0.78em; }
 .poster-cover-meta { font-family: 'Space Mono', monospace; font-size: 9px; letter-spacing: 3px; color: #666660; }
 .poster-cover-meta span { color: #F7931A; }
 .poster-cover-close { position: absolute; top: 24px; right: 24px; width: 44px; height: 44px; background: transparent; border: 1px solid rgba(255,255,255,0.18); color: #d4d0c8; font-family: 'Space Mono', monospace; font-size: 22px; line-height: 1; cursor: none; display: flex; align-items: center; justify-content: center; transition: all 0.2s; z-index: 1; }

--- a/photobook.html
+++ b/photobook.html
@@ -334,12 +334,12 @@ body {
       <img src="assets/posters/poster-01.jpg" alt="Frame 01" loading="lazy">
       <div class="photobook-frame-num">FRAME 01 / 03</div>
     </button>
-    <button class="photobook-frame" data-img="assets/posters/poster-02.jpg" data-num="02" aria-label="Open frame 02">
-      <img src="assets/posters/poster-02.jpg" alt="Frame 02" loading="lazy">
+    <button class="photobook-frame" data-img="assets/posters/poster-03.jpg" data-num="02" aria-label="Open frame 02">
+      <img src="assets/posters/poster-03.jpg" alt="Frame 02" loading="lazy">
       <div class="photobook-frame-num">FRAME 02 / 03</div>
     </button>
-    <button class="photobook-frame" data-img="assets/posters/poster-03.jpg" data-num="03" aria-label="Open frame 03">
-      <img src="assets/posters/poster-03.jpg" alt="Frame 03" loading="lazy">
+    <button class="photobook-frame" data-img="assets/posters/poster-02.jpg" data-num="03" aria-label="Open frame 03">
+      <img src="assets/posters/poster-02.jpg" alt="Frame 03" loading="lazy">
       <div class="photobook-frame-num">FRAME 03 / 03</div>
     </button>
   </div>


### PR DESCRIPTION
## Summary

Two small follow-ups that landed on the branch after PR #34 had already merged:

1. **Swap photobook frames 02 ↔ 03** (`photobook.html`)
   - FRAME 02 now shows the newsstand (poster-03.jpg)
   - FRAME 03 now shows mother + child (poster-02.jpg)
   - Files in `assets/posters/` untouched, so the cover overlay's poster→caption mapping in `index.html` doesn't drift.
2. **Shrink EN cover caption to 0.78em** (`index.html`)
   - EN sentences run longer than the TH equivalents; at parity size the trailing emoji wrapped to its own line. Scaling EN to ~78% keeps it on a single line on mobile. TH size unchanged.

## Files changed

- `photobook.html` — 4 lines (swap)
- `index.html` — 1 line (EN-only size rule)

## Test plan

- [ ] `/photobook.html` — frame 02 = newsstand, frame 03 = mother + child
- [ ] `/` cover with EN active — caption + emoji on one line at 375px

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvN2pieKMgc6rURksuFAVb)_