### PR TITLE
dialogue: Thai grammar, weekly rotation, UI copy updates

### DIFF
--- a/dialogue.html
+++ b/dialogue.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>SATOSHI — DIALOGUE บทสนทนา</title>
-<meta name="description" content="SATOSHI — เรื่องจริงของคนจริง กลายเป็นบทหนัง Real stories become the screenplay">
+<meta name="description" content="SATOSHI — สนทนาภาษาซาโตชิ — Speak Satoshi's Language">
 <meta property="og:title" content="SATOSHI — DIALOGUE">
 <meta property="og:description" content="ร่วมเขียนบทหนัง SATOSHI ด้วยเรื่องจริงของคุณ">
 <meta property="og:type" content="website">
@@ -787,10 +787,10 @@ function App() {
       <div style={{ marginBottom: 20 }}>
         <div style={{ textAlign: "center", marginBottom: 32 }}>
           <p style={{ fontFamily: "var(--thai)", color: "#8BA8C4", fontSize: "1.1rem", margin: "0 0 6px", lineHeight: 1.8 }}>
-            เรื่องจริงของคนจริง กลายเป็นบทหนัง
+            สนทนาภาษาซาโตชิ
           </p>
           <p style={{ fontFamily: "var(--mono)", color: "rgba(232,230,225,0.3)", fontSize: "0.72rem" }}>
-            Real stories from real people, becoming the screenplay
+            Speak Satoshi's Language
           </p>
         </div>
 
@@ -846,7 +846,7 @@ function App() {
               cursor: "pointer", letterSpacing: "0.15em", transition: "all 0.2s"
             }}
           >
-            🔀 RANDOM 5
+            RANDOM
           </button>
         </div>
 


### PR DESCRIPTION
## Summary

- **Line wrap fix** — `whiteSpace: nowrap` บน Divider label ให้ "เสียงจากต้นทาง" อยู่บรรทัดเดียว
- **Button** — `🔀 RANDOM 5` → `RANDOM`
- **Section tagline** — "เรื่องจริงของคนจริง กลายเป็นบทหนัง" → "สนทนาภาษาซาโตชิ" / "Speak Satoshi's Language"
- **Thai grammar** (Satoshi quotes):
  - sq_02: `P2P แท้จริง` → `P2P ที่แท้จริง` · เพิ่ม `จะ` ใน `ดูเหมือนจะยืนหยัด`
  - sq_03: `ย้อนหลัง` → `กลับด้าน` (backwards ≠ retroactively)
  - sq_05: `ค่าเงินเสื่อมลง` → `เงินเสื่อมค่า`
  - sq_06: `กระจายศูนย์` → `กระจายอำนาจ`
- **Weekly rotation** — เพิ่ม `pickWeekly()` seeded PRNG ให้ 5 quotes หมุนเองทุกสัปดาห์โดยอัตโนมัติ

https://claude.ai/code/session_01LhemVaDJFvS5XhiBNC25o5

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhemVaDJFvS5XhiBNC25o5)_