### PR TITLE
Move Okamoto, Ohta, Matsui into new Chapter I-J — Japan Lineage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1027,29 +1027,6 @@ function dismissPreProdBanner() {
         <div class="bundle-tags"><span>DigiCash 1989</span></div>
         <div class="bundle-score">80%</div>
       </div>
-      <div class="bundle-card" data-bundle="okamoto">
-        <button class="verify-btn" onclick="openTerminal('okamoto')" title="Don't Trust, Verify">✅ Verify</button>
-        <div class="bundle-name">Tatsuaki Okamoto</div>
-        <div class="bundle-role th-only">Universal Electronic Cash (1991) — สาย e-cash ญี่ปุ่นที่ NTT เกือบ deploy จริงปี 1996</div>
-        <div class="bundle-role en-only">Universal Electronic Cash (1991) — the Japanese e-cash line NTT nearly deployed in 1996.</div>
-        <div class="bundle-tags"><span>NTT Research</span><span>Crypto '91</span><span>Fujisaki-Okamoto</span></div>
-        <div class="bundle-score">65%</div>
-      </div>
-      <div class="bundle-card" data-bundle="ohta">
-        <button class="verify-btn" onclick="openTerminal('ohta')" title="Don't Trust, Verify">✅ Verify</button>
-        <div class="bundle-name">Kazuo Ohta</div>
-        <div class="bundle-role th-only">คู่หูวิจัยของ Okamoto — zero-knowledge proofs สำหรับ untraceable cash</div>
-        <div class="bundle-role en-only">Okamoto's research partner — zero-knowledge proofs for untraceable cash.</div>
-        <div class="bundle-tags"><span>NTT</span><span>Crypto '89</span><span>Zero-Knowledge</span></div>
-      </div>
-      <div class="bundle-card" data-bundle="matsui">
-        <button class="verify-btn" onclick="openTerminal('matsui')" title="Don't Trust, Verify">✅ Verify</button>
-        <div class="bundle-name">Mitsuru Matsui</div>
-        <div class="bundle-role th-only">Linear Cryptanalysis (1993) — คนแรกในโลกที่ break DES ได้จริง</div>
-        <div class="bundle-role en-only">Linear Cryptanalysis (1993) — the first to experimentally break DES.</div>
-        <div class="bundle-tags"><span>Mitsubishi Electric</span><span>MISTY</span><span>Camellia</span></div>
-        <div class="bundle-score">55%</div>
-      </div>
     </div>
   </div>
 
@@ -1185,6 +1162,47 @@ function dismissPreProdBanner() {
         <div class="bundle-tags"><span>BlackNet</span></div>
         <div class="bundle-score">74%</div>
       </div>
+    </div>
+  </div>
+
+  <!-- ═══ CHAPTER I-J — ELECTRONIC CASH: JAPAN LINEAGE ═══ -->
+  <div class="ch-group reveal">
+    <div class="ch-header">
+      <div class="ch-num">I-J</div>
+      <div class="ch-info">
+        <div class="ch-title">ELECTRONIC CASH — JAPAN LINEAGE</div>
+        <div class="ch-subtitle th-only">สายคู่ขนาน — นักวิจัยญี่ปุ่นที่ใช้คำว่า "electronic cash" ก่อน Satoshi 17 ปี ไม่ได้อยู่ใน whitepaper แต่หล่อหลอมคำและคณิตศาสตร์ที่ Satoshi สืบทอด</div>
+        <div class="ch-subtitle en-only">The parallel branch — Japanese researchers who used the phrase "electronic cash" 17 years before Satoshi. Not in the whitepaper, but they shaped the vocabulary and mathematics Satoshi inherited.</div>
+      </div>
+    </div>
+    <div class="ch-grid">
+
+      <div class="bundle-card" data-bundle="okamoto">
+        <button class="verify-btn" onclick="openTerminal('okamoto')" title="Don't Trust, Verify">✅ Verify</button>
+        <div class="bundle-name">Tatsuaki Okamoto</div>
+        <div class="bundle-role th-only">Universal Electronic Cash (1991) — สาย e-cash ญี่ปุ่นที่ NTT เกือบ deploy จริงปี 1996</div>
+        <div class="bundle-role en-only">Universal Electronic Cash (1991) — the Japanese e-cash line NTT nearly deployed in 1996.</div>
+        <div class="bundle-tags"><span>NTT Research</span><span>Crypto '91</span><span>Fujisaki-Okamoto</span></div>
+        <div class="bundle-score">65%</div>
+      </div>
+
+      <div class="bundle-card" data-bundle="ohta">
+        <button class="verify-btn" onclick="openTerminal('ohta')" title="Don't Trust, Verify">✅ Verify</button>
+        <div class="bundle-name">Kazuo Ohta</div>
+        <div class="bundle-role th-only">คู่หูวิจัยของ Okamoto — zero-knowledge proofs สำหรับ untraceable cash</div>
+        <div class="bundle-role en-only">Okamoto's research partner — zero-knowledge proofs for untraceable cash.</div>
+        <div class="bundle-tags"><span>NTT</span><span>Crypto '89</span><span>Zero-Knowledge</span></div>
+      </div>
+
+      <div class="bundle-card" data-bundle="matsui">
+        <button class="verify-btn" onclick="openTerminal('matsui')" title="Don't Trust, Verify">✅ Verify</button>
+        <div class="bundle-name">Mitsuru Matsui</div>
+        <div class="bundle-role th-only">Linear Cryptanalysis (1993) — คนแรกในโลกที่ break DES ได้จริง</div>
+        <div class="bundle-role en-only">Linear Cryptanalysis (1993) — the first to experimentally break DES.</div>
+        <div class="bundle-tags"><span>Mitsubishi Electric</span><span>MISTY</span><span>Camellia</span></div>
+        <div class="bundle-score">55%</div>
+      </div>
+
     </div>
   </div>
 


### PR DESCRIPTION
Extracts the three Japanese cryptographers from Chapter 0 (Whitepaper
Genesis) into a dedicated parallel chapter I-J (Electronic Cash: Japan
Lineage), placed between Chapter I and Chapter II.

Chapter I-J explicitly notes these figures are not cited in the Bitcoin
whitepaper but shaped the vocabulary and mathematics Satoshi inherited.
BUNDLES object entries are unchanged.

https://claude.ai/code/session_01PUyvgo62ReTx4HJAyjicpX