### PR TITLE
fix(forum): correct curated_date + always override from run date

### DIFF
--- a/forum-daily.json
+++ b/forum-daily.json
@@ -1,5 +1,5 @@
 {
-  "curated_date": "2025-06-04",
+  "curated_date": "2026-06-07",
   "block_height": "-",
   "curator_note_en": "This week's threads circle a quiet but urgent question: who built the cage, who holds the key, and whether the next generation will know the difference.",
   "curator_note_th": "สัปดาห์นี้ กระทู้ที่คัดสรรต่างวนเวียนอยู่กับคำถามเงียบๆ แต่เร่งด่วน ว่าใครสร้างกรง ใครถือกุญแจ และคนรุ่นต่อไปจะรู้ความต่างนั้นหรือไม่",

--- a/scripts/curate-forum.js
+++ b/scripts/curate-forum.js
@@ -350,9 +350,7 @@ async function callClaude(prompt) {
     }));
 
     const today = new Date().toISOString().slice(0, 10);
-    if (!parsed.curated_date || parsed.curated_date === "YYYY-MM-DD") {
-      parsed.curated_date = today;
-    }
+    parsed.curated_date = today;
 
     // Calculate ISO week and add to JSON
     const isoWeek = getISOWeek(new Date());


### PR DESCRIPTION
- forum-daily.json: fix curated_date from wrong "2025-06-04" to
  "2026-06-07" (the actual date the GitHub Action ran this week)
- curate-forum.js: remove conditional guard — always set curated_date
  to the actual run date so Claude's AI-generated date is never kept

Root cause: the script only overrode curated_date if it was missing or
"YYYY-MM-DD". When Claude returned a plausible-looking but wrong year
(e.g. "2025-06-04" for a 2026 run), it was silently kept.

https://claude.ai/code/session_01KY6uzf9b8Rfaa9UhY6w49d