### PR TITLE
Fix: DialogueCard crashes from missing WORLDS reference

### DIFF
--- a/dialogue.html
+++ b/dialogue.html
@@ -446,8 +446,9 @@ const SATOSHI_QUOTES = [
 
 
 // ─── DIALOGUE CARD COMPONENT ───────────────
+const WORLD_COLORS = { A: "#D4A574", B: "#8BA8C4", C: "#D4AF37" };
 function DialogueCard({ d, compact, onSelect, selected }) {
-  const color = WORLDS[d.world]?.color || "#F7931A";
+  const color = WORLD_COLORS[d.world] || "#F7931A";
   
   return (
     <div


### PR DESCRIPTION
Fix ReferenceError ใน `DialogueCard` ที่ยังเรียก `WORLDS[d.world]?.color` หลังจาก `WORLDS` ถูกลบออก

แก้โดยเพิ่ม `WORLD_COLORS = { A: "#D4A574", B: "#8BA8C4", C: "#D4AF37" }` แทน

---
_Generated by [Claude Code](https://claude.ai/code/session_013BCnjSrTUaUeKxSzc5ay7z)_