### PR TITLE
Add BFF'26 festival credit, press kit, and feature funding pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,8 @@ fiat money, and Bitcoin — told through one ordinary family across four generat
 |photobook.html|Live   |Poster display page. assets/posters/ has 3 posters. |
 |forum.html    |Live   |Standalone forum page. Fed by forum-daily.json.     |
 |verifier.html |Live   |SEED — quote miner + freedom vocabulary generator.  |
+|support.html  |Live   |Feature funding — Lightning + investor contact.     |
+|press.html    |Live   |Press kit — logline, synopsis, teaser, festival.    |
 
 **Migration trigger for forum.html:** when forum content exceeds inline capacity
 inside index.html. Until then, forum lives as `<section id="forum">` in index.html.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 This repository contains the source code for the official interactive website of the **SATOSHi** feature film project.
 
+🏆 **Official Selection — Bitcoin FilmFest 2026, Warsaw** — screened in the "Changing minds with fiction" block (June 2026). Now raising support for the full feature.
+
 🌐 **Live Site:** <https://sootisooti.github.io/satoshi.film/>
 
 ---
@@ -20,8 +22,8 @@ This repository contains the source code for the official interactive website of
 ## 🟩 Features — ฟีเจอร์หลัก
 
 ### 🎬 Narrative & Content
-- **Hero Section** — introduce the film with universal bilingual copy
-- **Three Worlds** — Past (โลก A) / Present (โลก B) / Future (โลก C)
+- **Hero Section** — introduce the film with universal bilingual copy + BFF'26 festival laurel
+- **Timeline** — Truth / Past / Present / Future (ความจริง / อดีต / ปัจจุบัน / อนาคต)
 - **Halving Timeline** — interactive timeline with user memory fields
 - **Cypherpunk Directory** — **44+ bundle cards across 13 chapters** (including new **Chapter -1: The Forethinkers Root** tracing Austrian economics lineage from 1871)
 - **Verify Terminal Modal** — interactive AI-powered terminal wired to Anthropic API (`claude-sonnet-4-20250514`)
@@ -51,6 +53,8 @@ This repository contains the source code for the official interactive website of
 | `dialogue.html` | Screenplay writing feature (บทภาพยนตร์) | ✅ Live |
 | `photobook.html` | Visual diary / production stills (หนังสือภาพ) | 🚧 Placeholder |
 | `forum.html` | Curated bitcointalk threads (standalone) | 📋 Planned |
+| `support.html` | Feature funding — Lightning + investor contact | ✅ Live |
+| `press.html` | Press kit — logline, synopsis, teaser, key art, festival credit | ✅ Live |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 This repository contains the source code for the official interactive website of the **SATOSHi** feature film project.
 
-🏆 **Official Selection — Bitcoin FilmFest 2026, Warsaw** — screened in the "Changing minds with fiction" block (June 2026). Now raising support for the full feature.
+🏆 **Official Selection — Bitcoin FilmFest 2026, Warsaw** — the official teaser screened in the "Changing minds with fiction" block (June 2026). Now raising support for the full feature.
 
 🌐 **Live Site:** <https://sootisooti.github.io/satoshi.film/>
 

--- a/assets/laurel-bff26.svg
+++ b/assets/laurel-bff26.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 300" role="img" aria-label="Official Selection — Bitcoin FilmFest 2026, Warsaw">
+  <defs>
+    <path id="leaf" d="M0 0 C 5.5 -9 6.5 -21 0 -34 C -6.5 -21 -5.5 -9 0 0 Z"/>
+    <g id="branch">
+      <path d="M337.9 275.7 L319.3 277.4 L300.5 278.0 L281.8 277.5 L263.1 275.8 L244.8 273.1 L226.9 269.3 L209.5 264.5 L192.8 258.6 L176.8 251.8 L161.8 244.0 L147.8 235.4 L135.0 226.0 L123.3 215.9 L113.0 205.1 L104.1 193.8 L96.6 181.9 L90.6 169.7 L86.2 157.1 L83.3 144.4 L82.1 131.5 L82.4 118.6 L84.4 105.7 L88.0 93.1 L93.1 80.7 L99.8 68.6 L108.0 57.0 L117.6 45.9 L128.5 35.4 L140.7 25.6 L154.1 16.5" fill="none" stroke="#FFFFFF" stroke-width="2.5" stroke-linecap="round"/>
+      <use href="#leaf" transform="translate(337.9 275.7) rotate(-122.9) scale(1.05)"/>
+      <use href="#leaf" transform="translate(300.5 278.0) rotate(-64.1) scale(1.02)"/>
+      <use href="#leaf" transform="translate(263.1 275.8) rotate(-109.3) scale(0.99)"/>
+      <use href="#leaf" transform="translate(226.9 269.3) rotate(-50.2) scale(0.96)"/>
+      <use href="#leaf" transform="translate(192.8 258.6) rotate(-94.8) scale(0.93)"/>
+      <use href="#leaf" transform="translate(161.8 244.0) rotate(-34.6) scale(0.90)"/>
+      <use href="#leaf" transform="translate(135.0 226.0) rotate(-77.4) scale(0.87)"/>
+      <use href="#leaf" transform="translate(113.0 205.1) rotate(-15.1) scale(0.84)"/>
+      <use href="#leaf" transform="translate(96.6 181.9) rotate(-55.2) scale(0.81)"/>
+      <use href="#leaf" transform="translate(86.2 157.1) rotate(9.9) scale(0.78)"/>
+      <use href="#leaf" transform="translate(82.1 131.5) rotate(-27.9) scale(0.75)"/>
+      <use href="#leaf" transform="translate(84.4 105.7) rotate(38.3) scale(0.72)"/>
+      <use href="#leaf" transform="translate(93.1 80.7) rotate(-0.2) scale(0.69)"/>
+      <use href="#leaf" transform="translate(108.0 57.0) rotate(64.0) scale(0.66)"/>
+      <use href="#leaf" transform="translate(128.5 35.4) rotate(22.8) scale(0.63)"/>
+      <use href="#leaf" transform="translate(154.1 16.5) rotate(58.2) scale(0.60)"/>
+    </g>
+  </defs>
+  <g fill="#FFFFFF">
+    <use href="#branch"/>
+    <use href="#branch" transform="translate(600 0) scale(-1 1)"/>
+  </g>
+  <g fill="#FFFFFF" text-anchor="middle" font-family="'Space Mono','Courier New',monospace">
+    <text x="300" y="106" font-size="20" letter-spacing="5">OFFICIAL SELECTION</text>
+    <text x="300" y="152" font-size="30" font-weight="700" letter-spacing="1">BITCOIN FILMFEST</text>
+    <text x="300" y="194" font-size="19" letter-spacing="6">2026 · WARSAW</text>
+  </g>
+</svg>

--- a/assets/laurel-bff26.svg
+++ b/assets/laurel-bff26.svg
@@ -1,24 +1,45 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 300" role="img" aria-label="Official Selection — Bitcoin FilmFest 2026, Warsaw">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 300" role="img" aria-label="Official Selection — Bitcoin FilmFest 2026, Warsaw" shape-rendering="crispEdges">
   <defs>
-    <path id="leaf" d="M0 0 C 5.5 -9 6.5 -21 0 -34 C -6.5 -21 -5.5 -9 0 0 Z"/>
     <g id="branch">
-      <path d="M337.9 275.7 L319.3 277.4 L300.5 278.0 L281.8 277.5 L263.1 275.8 L244.8 273.1 L226.9 269.3 L209.5 264.5 L192.8 258.6 L176.8 251.8 L161.8 244.0 L147.8 235.4 L135.0 226.0 L123.3 215.9 L113.0 205.1 L104.1 193.8 L96.6 181.9 L90.6 169.7 L86.2 157.1 L83.3 144.4 L82.1 131.5 L82.4 118.6 L84.4 105.7 L88.0 93.1 L93.1 80.7 L99.8 68.6 L108.0 57.0 L117.6 45.9 L128.5 35.4 L140.7 25.6 L154.1 16.5" fill="none" stroke="#FFFFFF" stroke-width="2.5" stroke-linecap="round"/>
-      <use href="#leaf" transform="translate(337.9 275.7) rotate(-122.9) scale(1.05)"/>
-      <use href="#leaf" transform="translate(300.5 278.0) rotate(-64.1) scale(1.02)"/>
-      <use href="#leaf" transform="translate(263.1 275.8) rotate(-109.3) scale(0.99)"/>
-      <use href="#leaf" transform="translate(226.9 269.3) rotate(-50.2) scale(0.96)"/>
-      <use href="#leaf" transform="translate(192.8 258.6) rotate(-94.8) scale(0.93)"/>
-      <use href="#leaf" transform="translate(161.8 244.0) rotate(-34.6) scale(0.90)"/>
-      <use href="#leaf" transform="translate(135.0 226.0) rotate(-77.4) scale(0.87)"/>
-      <use href="#leaf" transform="translate(113.0 205.1) rotate(-15.1) scale(0.84)"/>
-      <use href="#leaf" transform="translate(96.6 181.9) rotate(-55.2) scale(0.81)"/>
-      <use href="#leaf" transform="translate(86.2 157.1) rotate(9.9) scale(0.78)"/>
-      <use href="#leaf" transform="translate(82.1 131.5) rotate(-27.9) scale(0.75)"/>
-      <use href="#leaf" transform="translate(84.4 105.7) rotate(38.3) scale(0.72)"/>
-      <use href="#leaf" transform="translate(93.1 80.7) rotate(-0.2) scale(0.69)"/>
-      <use href="#leaf" transform="translate(108.0 57.0) rotate(64.0) scale(0.66)"/>
-      <use href="#leaf" transform="translate(128.5 35.4) rotate(22.8) scale(0.63)"/>
-      <use href="#leaf" transform="translate(154.1 16.5) rotate(58.2) scale(0.60)"/>
+      <rect x="160" y="0" width="10" height="10"/>
+      <rect x="180" y="0" width="10" height="10"/>
+      <rect x="140" y="10" width="20" height="10"/>
+      <rect x="110" y="20" width="40" height="10"/>
+      <rect x="110" y="30" width="30" height="10"/>
+      <rect x="110" y="40" width="30" height="10"/>
+      <rect x="70" y="50" width="10" height="10"/>
+      <rect x="90" y="50" width="30" height="10"/>
+      <rect x="80" y="60" width="40" height="10"/>
+      <rect x="90" y="70" width="30" height="10"/>
+      <rect x="80" y="80" width="20" height="10"/>
+      <rect x="60" y="90" width="50" height="10"/>
+      <rect x="70" y="100" width="30" height="10"/>
+      <rect x="80" y="110" width="10" height="10"/>
+      <rect x="80" y="120" width="10" height="10"/>
+      <rect x="80" y="130" width="10" height="10"/>
+      <rect x="80" y="140" width="30" height="10"/>
+      <rect x="70" y="150" width="30" height="10"/>
+      <rect x="60" y="160" width="40" height="10"/>
+      <rect x="90" y="170" width="20" height="10"/>
+      <rect x="120" y="170" width="10" height="10"/>
+      <rect x="80" y="180" width="40" height="10"/>
+      <rect x="80" y="190" width="30" height="10"/>
+      <rect x="100" y="200" width="30" height="10"/>
+      <rect x="100" y="210" width="30" height="10"/>
+      <rect x="100" y="220" width="60" height="10"/>
+      <rect x="140" y="230" width="20" height="10"/>
+      <rect x="190" y="230" width="10" height="10"/>
+      <rect x="130" y="240" width="10" height="10"/>
+      <rect x="150" y="240" width="50" height="10"/>
+      <rect x="140" y="250" width="10" height="10"/>
+      <rect x="170" y="250" width="30" height="10"/>
+      <rect x="230" y="250" width="10" height="10"/>
+      <rect x="130" y="260" width="10" height="10"/>
+      <rect x="170" y="260" width="70" height="10"/>
+      <rect x="170" y="270" width="10" height="10"/>
+      <rect x="230" y="270" width="80" height="10"/>
+      <rect x="210" y="280" width="20" height="10"/>
+      <rect x="210" y="290" width="10" height="10"/>
     </g>
   </defs>
   <g fill="#FFFFFF">

--- a/dialogue.html
+++ b/dialogue.html
@@ -132,8 +132,8 @@
 <div id="preProdBanner" class="preprod-banner">
   <div class="preprod-content">
     <span class="preprod-text">
-      <span>เว็บไซต์และภาพยนตร์อยู่ในช่วง pre-production · ขออภัยด้วยหาก feature บางส่วนยังไม่ทำงาน</span>
-      <span>Website and film are in pre-production · Apologies if some features don't work yet</span>
+      <span>ฉายแล้วที่ Bitcoin FilmFest 2026 วอร์ซอ — กำลังระดมทุนสร้างฉบับเต็ม · ขออภัยหาก feature บางส่วนยังไม่ทำงาน</span>
+      <span>Screened at Bitcoin FilmFest 2026, Warsaw — now raising the full feature · Apologies if some features don't work yet</span>
     </span>
     <button class="preprod-close" onclick="dismissPreProdBanner()" aria-label="Close banner">×</button>
   </div>

--- a/dialogue.html
+++ b/dialogue.html
@@ -132,8 +132,8 @@
 <div id="preProdBanner" class="preprod-banner">
   <div class="preprod-content">
     <span class="preprod-text">
-      <span>ฉายแล้วที่ Bitcoin FilmFest 2026 วอร์ซอ — กำลังระดมทุนสร้างฉบับเต็ม · ขออภัยหาก feature บางส่วนยังไม่ทำงาน</span>
-      <span>Screened at Bitcoin FilmFest 2026, Warsaw — now raising the full feature · Apologies if some features don't work yet</span>
+      <span>Teaser ฉายแล้วที่ Bitcoin FilmFest 2026 วอร์ซอ — กำลังระดมทุนสร้างฉบับเต็ม · ขออภัยหาก feature บางส่วนยังไม่ทำงาน</span>
+      <span>Teaser screened at Bitcoin FilmFest 2026, Warsaw — now raising the full feature · Apologies if some features don't work yet</span>
     </span>
     <button class="preprod-close" onclick="dismissPreProdBanner()" aria-label="Close banner">×</button>
   </div>

--- a/forum.html
+++ b/forum.html
@@ -167,8 +167,8 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
 <div id="preProdBanner" class="preprod-banner">
   <div class="preprod-content">
     <span class="preprod-text">
-      <span>เว็บไซต์และภาพยนตร์อยู่ในช่วง pre-production · ขออภัยด้วยหาก feature บางส่วนยังไม่ทำงาน</span>
-      <span>Website and film are in pre-production · Apologies if some features don't work yet</span>
+      <span>ฉายแล้วที่ Bitcoin FilmFest 2026 วอร์ซอ — กำลังระดมทุนสร้างฉบับเต็ม · ขออภัยหาก feature บางส่วนยังไม่ทำงาน</span>
+      <span>Screened at Bitcoin FilmFest 2026, Warsaw — now raising the full feature · Apologies if some features don't work yet</span>
     </span>
     <button class="preprod-close" onclick="dismissPreProdBanner()" aria-label="Close banner">×</button>
   </div>

--- a/forum.html
+++ b/forum.html
@@ -167,8 +167,8 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
 <div id="preProdBanner" class="preprod-banner">
   <div class="preprod-content">
     <span class="preprod-text">
-      <span>ฉายแล้วที่ Bitcoin FilmFest 2026 วอร์ซอ — กำลังระดมทุนสร้างฉบับเต็ม · ขออภัยหาก feature บางส่วนยังไม่ทำงาน</span>
-      <span>Screened at Bitcoin FilmFest 2026, Warsaw — now raising the full feature · Apologies if some features don't work yet</span>
+      <span>Teaser ฉายแล้วที่ Bitcoin FilmFest 2026 วอร์ซอ — กำลังระดมทุนสร้างฉบับเต็ม · ขออภัยหาก feature บางส่วนยังไม่ทำงาน</span>
+      <span>Teaser screened at Bitcoin FilmFest 2026, Warsaw — now raising the full feature · Apologies if some features don't work yet</span>
     </span>
     <button class="preprod-close" onclick="dismissPreProdBanner()" aria-label="Close banner">×</button>
   </div>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="SATOSHI.FILM">
 <meta property="og:title" content="SATOSHI — ซาโตชิ | Official Selection — Bitcoin FilmFest 2026, Warsaw">
-<meta property="og:description" content="A Thai family drama across four generations — debt, fiat money, and truth that waits to be verified. Screened at Bitcoin FilmFest 2026, Warsaw. Now raising support for the full feature.">
+<meta property="og:description" content="A Thai family drama across four generations — debt, fiat money, and truth that waits to be verified. Official teaser screened at Bitcoin FilmFest 2026, Warsaw. Now raising support for the full feature.">
 <meta property="og:url" content="https://sootisooti.github.io/satoshi.film/">
 <meta property="og:image" content="https://sootisooti.github.io/satoshi.film/assets/posters/poster-01.jpg">
 <meta name="twitter:card" content="summary_large_image">
@@ -609,8 +609,8 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
 <div id="preProdBanner" class="preprod-banner">
   <div class="preprod-content">
     <span class="preprod-text">
-      <span>ฉายแล้วที่ Bitcoin FilmFest 2026 วอร์ซอ — กำลังระดมทุนสร้างฉบับเต็ม · ขออภัยหาก feature บางส่วนยังไม่ทำงาน</span>
-      <span>Screened at Bitcoin FilmFest 2026, Warsaw — now raising the full feature · Apologies if some features don't work yet</span>
+      <span>Teaser ฉายแล้วที่ Bitcoin FilmFest 2026 วอร์ซอ — กำลังระดมทุนสร้างฉบับเต็ม · ขออภัยหาก feature บางส่วนยังไม่ทำงาน</span>
+      <span>Teaser screened at Bitcoin FilmFest 2026, Warsaw — now raising the full feature · Apologies if some features don't work yet</span>
     </span>
     <button class="preprod-close" onclick="dismissPreProdBanner()" aria-label="Close banner">×</button>
   </div>
@@ -845,17 +845,17 @@ function dismissPreProdBanner() {
     <div class="bff-section-year">2 0 2 6 — WARSAW</div>
     <div class="bff-section-divider"></div>
     <div class="bff-section-desc">
-      <span class="th-only">SATOSHI ได้รับคัดเลือกอย่างเป็นทางการ และฉายแล้วที่ <strong>Bitcoin FilmFest 2026</strong> กรุงวอร์ซอ ในบล็อกภาพยนตร์ <strong>"Changing minds with fiction"</strong> — เทศกาลภาพยนตร์นานาชาติที่อุทิศให้กับเรื่องราวของ Bitcoin ความจริง และอิสรภาพทางการเงิน ขณะนี้กำลังระดมทุนเพื่อสร้างภาพยนตร์ฉบับเต็ม</span>
-      <span class="en-only">SATOSHI is an Official Selection of <strong>Bitcoin FilmFest 2026</strong>, Warsaw — screened in the festival's <strong>"Changing minds with fiction"</strong> block. The festival is dedicated to Bitcoin, truth, and financial freedom. The film is now raising support for the full feature.</span>
+      <span class="th-only">SATOSHI ได้รับคัดเลือกอย่างเป็นทางการ โดย <strong>teaser</strong> ได้ฉายแล้วที่ <strong>Bitcoin FilmFest 2026</strong> กรุงวอร์ซอ ในบล็อกภาพยนตร์ <strong>"Changing minds with fiction"</strong> — เทศกาลภาพยนตร์นานาชาติที่อุทิศให้กับเรื่องราวของ Bitcoin ความจริง และอิสรภาพทางการเงิน แค่ teaser ก็ได้ slot คืนวันศุกร์มาแล้ว — ขณะนี้กำลังระดมทุนเพื่อสร้างภาพยนตร์ฉบับเต็ม</span>
+      <span class="en-only">SATOSHI is an Official Selection of <strong>Bitcoin FilmFest 2026</strong>, Warsaw — its <strong>official teaser</strong> screened in the festival's <strong>"Changing minds with fiction"</strong> block. The festival is dedicated to Bitcoin, truth, and financial freedom. The teaser alone earned a Friday prime-time slot — the film is now raising support for the full feature.</span>
     </div>
     <div class="screenings" id="screenings">
       <div class="screenings-label">SCREENINGS</div>
       <div class="screening-row">
-        <span class="screening-date">JUNE 2026</span>
+        <span class="screening-date">JUNE 2026 · OFFICIAL TEASER</span>
         <span class="screening-venue">BITCOIN FILMFEST 2026 — WARSAW, POLAND</span>
         <span class="screening-detail">
-          <span class="th-only">บล็อก "Changing minds with fiction" — ช่วงภาพยนตร์ fiction คืนวันศุกร์ (prime-time)</span>
-          <span class="en-only">"Changing minds with fiction" block — Friday 18:00 prime-time fiction slot</span>
+          <span class="th-only">Teaser อย่างเป็นทางการ ฉายในบล็อก "Changing minds with fiction" — ช่วงภาพยนตร์ fiction คืนวันศุกร์ (prime-time)</span>
+          <span class="en-only">Official teaser — "Changing minds with fiction" block, Friday 18:00 prime-time fiction slot</span>
         </span>
         <a href="https://bitcoinfilmfest.com/bff26/" target="_blank" rel="noopener" class="screening-link">SOURCE: bitcoinfilmfest.com/bff26 ↗</a>
       </div>

--- a/index.html
+++ b/index.html
@@ -783,27 +783,48 @@ function dismissPreProdBanner() {
   <h1 class="hero-title">SATOSHi</h1>
   <div class="hero-title-th">ซ า โ ต ชิ</div>
   <a href="#bff" class="hero-laurel" style="color:#F7F3E8;" aria-label="Official Selection — Bitcoin FilmFest 2026, Warsaw">
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 300" role="img">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 300" role="img" shape-rendering="crispEdges">
       <defs>
-        <path id="heroLeaf" d="M0 0 C 5.5 -9 6.5 -21 0 -34 C -6.5 -21 -5.5 -9 0 0 Z"/>
         <g id="heroBranch">
-          <path d="M337.9 275.7 L319.3 277.4 L300.5 278.0 L281.8 277.5 L263.1 275.8 L244.8 273.1 L226.9 269.3 L209.5 264.5 L192.8 258.6 L176.8 251.8 L161.8 244.0 L147.8 235.4 L135.0 226.0 L123.3 215.9 L113.0 205.1 L104.1 193.8 L96.6 181.9 L90.6 169.7 L86.2 157.1 L83.3 144.4 L82.1 131.5 L82.4 118.6 L84.4 105.7 L88.0 93.1 L93.1 80.7 L99.8 68.6 L108.0 57.0 L117.6 45.9 L128.5 35.4 L140.7 25.6 L154.1 16.5" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
-          <use href="#heroLeaf" transform="translate(337.9 275.7) rotate(-122.9) scale(1.05)"/>
-          <use href="#heroLeaf" transform="translate(300.5 278.0) rotate(-64.1) scale(1.02)"/>
-          <use href="#heroLeaf" transform="translate(263.1 275.8) rotate(-109.3) scale(0.99)"/>
-          <use href="#heroLeaf" transform="translate(226.9 269.3) rotate(-50.2) scale(0.96)"/>
-          <use href="#heroLeaf" transform="translate(192.8 258.6) rotate(-94.8) scale(0.93)"/>
-          <use href="#heroLeaf" transform="translate(161.8 244.0) rotate(-34.6) scale(0.90)"/>
-          <use href="#heroLeaf" transform="translate(135.0 226.0) rotate(-77.4) scale(0.87)"/>
-          <use href="#heroLeaf" transform="translate(113.0 205.1) rotate(-15.1) scale(0.84)"/>
-          <use href="#heroLeaf" transform="translate(96.6 181.9) rotate(-55.2) scale(0.81)"/>
-          <use href="#heroLeaf" transform="translate(86.2 157.1) rotate(9.9) scale(0.78)"/>
-          <use href="#heroLeaf" transform="translate(82.1 131.5) rotate(-27.9) scale(0.75)"/>
-          <use href="#heroLeaf" transform="translate(84.4 105.7) rotate(38.3) scale(0.72)"/>
-          <use href="#heroLeaf" transform="translate(93.1 80.7) rotate(-0.2) scale(0.69)"/>
-          <use href="#heroLeaf" transform="translate(108.0 57.0) rotate(64.0) scale(0.66)"/>
-          <use href="#heroLeaf" transform="translate(128.5 35.4) rotate(22.8) scale(0.63)"/>
-          <use href="#heroLeaf" transform="translate(154.1 16.5) rotate(58.2) scale(0.60)"/>
+          <rect x="160" y="0" width="10" height="10"/>
+          <rect x="180" y="0" width="10" height="10"/>
+          <rect x="140" y="10" width="20" height="10"/>
+          <rect x="110" y="20" width="40" height="10"/>
+          <rect x="110" y="30" width="30" height="10"/>
+          <rect x="110" y="40" width="30" height="10"/>
+          <rect x="70" y="50" width="10" height="10"/>
+          <rect x="90" y="50" width="30" height="10"/>
+          <rect x="80" y="60" width="40" height="10"/>
+          <rect x="90" y="70" width="30" height="10"/>
+          <rect x="80" y="80" width="20" height="10"/>
+          <rect x="60" y="90" width="50" height="10"/>
+          <rect x="70" y="100" width="30" height="10"/>
+          <rect x="80" y="110" width="10" height="10"/>
+          <rect x="80" y="120" width="10" height="10"/>
+          <rect x="80" y="130" width="10" height="10"/>
+          <rect x="80" y="140" width="30" height="10"/>
+          <rect x="70" y="150" width="30" height="10"/>
+          <rect x="60" y="160" width="40" height="10"/>
+          <rect x="90" y="170" width="20" height="10"/>
+          <rect x="120" y="170" width="10" height="10"/>
+          <rect x="80" y="180" width="40" height="10"/>
+          <rect x="80" y="190" width="30" height="10"/>
+          <rect x="100" y="200" width="30" height="10"/>
+          <rect x="100" y="210" width="30" height="10"/>
+          <rect x="100" y="220" width="60" height="10"/>
+          <rect x="140" y="230" width="20" height="10"/>
+          <rect x="190" y="230" width="10" height="10"/>
+          <rect x="130" y="240" width="10" height="10"/>
+          <rect x="150" y="240" width="50" height="10"/>
+          <rect x="140" y="250" width="10" height="10"/>
+          <rect x="170" y="250" width="30" height="10"/>
+          <rect x="230" y="250" width="10" height="10"/>
+          <rect x="130" y="260" width="10" height="10"/>
+          <rect x="170" y="260" width="70" height="10"/>
+          <rect x="170" y="270" width="10" height="10"/>
+          <rect x="230" y="270" width="80" height="10"/>
+          <rect x="210" y="280" width="20" height="10"/>
+          <rect x="210" y="290" width="10" height="10"/>
         </g>
       </defs>
       <g fill="currentColor">

--- a/index.html
+++ b/index.html
@@ -3,8 +3,19 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>SATOSHI — ซาโตชิ</title>
-<meta name="description" content="เราทุกคนถูกขังอยู่ในระบบที่ออกแบบมาเพื่อให้แพ้ — ความจริงรอการตรวจสอบจากทุกคน">
+<title>SATOSHI — ซาโตชิ | Official Selection — Bitcoin FilmFest 2026, Warsaw</title>
+<meta name="description" content="A Thai family drama across four generations — debt, fiat money, and truth that waits to be verified. Official Selection — Bitcoin FilmFest 2026, Warsaw. เราทุกคนถูกขังอยู่ในระบบที่ออกแบบมาเพื่อให้แพ้ — ความจริงรอการตรวจสอบจากทุกคน">
+<link rel="canonical" href="https://sootisooti.github.io/satoshi.film/">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="SATOSHI.FILM">
+<meta property="og:title" content="SATOSHI — ซาโตชิ | Official Selection — Bitcoin FilmFest 2026, Warsaw">
+<meta property="og:description" content="A Thai family drama across four generations — debt, fiat money, and truth that waits to be verified. Screened at Bitcoin FilmFest 2026, Warsaw. Now raising support for the full feature.">
+<meta property="og:url" content="https://sootisooti.github.io/satoshi.film/">
+<meta property="og:image" content="https://sootisooti.github.io/satoshi.film/assets/posters/poster-01.jpg">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="SATOSHI — ซาโตชิ | Official Selection — Bitcoin FilmFest 2026, Warsaw">
+<meta name="twitter:description" content="A Thai family drama across four generations — debt, fiat money, and truth that waits to be verified.">
+<meta name="twitter:image" content="https://sootisooti.github.io/satoshi.film/assets/posters/poster-01.jpg">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Space+Mono:ital,wght@0,400;0,700;1,400&family=Noto+Serif+Thai:wght@400;700&family=Sarabun:wght@300;400;600;700&display=swap" rel="stylesheet">
@@ -44,7 +55,10 @@ nav { position: fixed; top: 0; left: 0; right: 0; z-index: 1000; display: grid; 
 .hero-block a:hover { color: #F7931A; }
 .hero-block .block-num { color: #F7931A; }
 .hero-title { font-family: 'Space Mono', monospace; font-size: clamp(48px, 12vw, 140px); font-weight: 700; letter-spacing: 0.1em; color: #d4d0c8; opacity: 0.15; line-height: 1; margin-bottom: 8px; }
-.hero-title-th { font-family: 'Noto Serif Thai', serif; font-size: clamp(24px, 5vw, 52px); color: #F7931A; opacity: 0.6; letter-spacing: 0.5em; margin-bottom: 60px; }
+.hero-title-th { font-family: 'Noto Serif Thai', serif; font-size: clamp(24px, 5vw, 52px); color: #F7931A; opacity: 0.6; letter-spacing: 0.5em; margin-bottom: 40px; }
+.hero-laurel { display: block; width: min(320px, 76vw); margin: 0 auto 44px; opacity: 0.9; transition: opacity 0.3s; }
+.hero-laurel:hover { opacity: 1; }
+.hero-laurel svg { width: 100%; height: auto; display: block; }
 .hero-premise { max-width: 700px; margin: 0 auto; }
 .hero-premise p { font-family: 'Sarabun', sans-serif; font-size: 16px; line-height: 2; color: #666660; margin-bottom: 12px; }
 .hero-premise .highlight { color: #F7931A; font-weight: 600; }
@@ -55,12 +69,13 @@ nav { position: fixed; top: 0; left: 0; right: 0; z-index: 1000; display: grid; 
 
 .section-divider { width: 100%; height: 1px; background: linear-gradient(90deg, transparent, #666660 20%, #666660 80%, transparent); opacity: 0.2; margin: 0; }
 
-/* ─── THREE WORLDS ─── */
+/* ─── TIMELINE — TRUTH / PAST / PRESENT / FUTURE ─── */
 .worlds { padding: 120px 40px; }
 .section-header { text-align: center; margin-bottom: 80px; }
 .section-header-label { font-family: 'Space Mono', monospace; font-size: 11px; letter-spacing: 4px; color: #F7931A; margin-bottom: 12px; }
 .section-header-title { font-family: 'Noto Serif Thai', serif; font-size: 20px; color: #666660; }
-.worlds-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 2px; max-width: 1100px; margin: 0 auto; }
+.worlds-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 2px; max-width: 1240px; margin: 0 auto; }
+@media (max-width: 1100px) { .worlds-grid { grid-template-columns: repeat(2, 1fr); } }
 .world-card { background: #0e0e0b; padding: 50px 36px; border-top: 2px solid transparent; transition: all 0.5s; position: relative; overflow: hidden; }
 .world-card::before { content: ''; position: absolute; top: 0; left: 0; right: 0; height: 2px; background: #F7931A; transform: scaleX(0); transition: transform 0.5s; }
 .world-card:hover::before { transform: scaleX(1); }
@@ -522,9 +537,21 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
 .bff-section-desc { font-family: 'Sarabun', sans-serif; font-size: 15px; line-height: 1.9; color: #666660; max-width: 600px; }
 .bff-section-cta { font-family: 'Space Mono', monospace; font-size: 11px; letter-spacing: 2px; color: #00FF41; border: 1px solid rgba(0,255,65,0.3); padding: 12px 28px; background: transparent; cursor: none; transition: all 0.3s; text-decoration: none; display: inline-block; margin-top: 4px; }
 .bff-section-cta:hover { background: rgba(0,255,65,0.08); border-color: #00FF41; }
+.bff-section-ctas { display: flex; gap: 12px; flex-wrap: wrap; justify-content: center; }
+.bff-section-cta.cta-orange { color: #F7931A; border-color: rgba(247,147,26,0.35); }
+.bff-section-cta.cta-orange:hover { background: rgba(247,147,26,0.08); border-color: #F7931A; }
+.screenings { width: 100%; max-width: 640px; margin-top: 8px; text-align: left; }
+.screenings-label { font-family: 'Space Mono', monospace; font-size: 10px; letter-spacing: 5px; color: #666660; margin-bottom: 14px; text-align: center; }
+.screening-row { border: 1px solid rgba(255,255,255,0.08); background: rgba(255,255,255,0.02); padding: 20px 24px; display: flex; flex-direction: column; gap: 6px; }
+.screening-date { font-family: 'Space Mono', monospace; font-size: 11px; letter-spacing: 3px; color: #F7931A; }
+.screening-venue { font-family: 'Space Mono', monospace; font-size: 13px; letter-spacing: 1px; color: #d4d0c8; }
+.screening-detail { font-family: 'Sarabun', sans-serif; font-size: 14px; line-height: 1.7; color: #666660; }
+.screening-link { font-family: 'Space Mono', monospace; font-size: 10px; letter-spacing: 1px; color: #00FF41; text-decoration: none; margin-top: 6px; transition: color 0.3s; }
+.screening-link:hover { color: #F7931A; }
 @media (max-width: 640px) {
   .bff-section { padding: 60px 20px; }
   .bff-section-desc { font-size: 14px; }
+  .screening-row { padding: 16px 18px; }
 }
 </style>
 </head>
@@ -545,8 +572,8 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
       <div class="bff-badge">
         <span class="bff-badge-icon">◈</span>
         <span class="bff-badge-text">
-          <span class="th-only">ส่งเข้าร่วม · <strong>BITCOIN FILM FEST 2026</strong></span>
-          <span class="en-only">Submitted to · <strong>BITCOIN FILM FEST 2026</strong></span>
+          <span class="th-only">ได้รับคัดเลือกอย่างเป็นทางการ · <strong>BITCOIN FILMFEST 2026 — WARSAW</strong></span>
+          <span class="en-only">OFFICIAL SELECTION · <strong>BITCOIN FILMFEST 2026 — WARSAW</strong></span>
         </span>
       </div>
     </div>
@@ -582,8 +609,8 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
 <div id="preProdBanner" class="preprod-banner">
   <div class="preprod-content">
     <span class="preprod-text">
-      <span>เว็บไซต์และภาพยนตร์อยู่ในช่วง pre-production · ขออภัยด้วยหาก feature บางส่วนยังไม่ทำงาน</span>
-      <span>Website and film are in pre-production · Apologies if some features don't work yet</span>
+      <span>ฉายแล้วที่ Bitcoin FilmFest 2026 วอร์ซอ — กำลังระดมทุนสร้างฉบับเต็ม · ขออภัยหาก feature บางส่วนยังไม่ทำงาน</span>
+      <span>Screened at Bitcoin FilmFest 2026, Warsaw — now raising the full feature · Apologies if some features don't work yet</span>
     </span>
     <button class="preprod-close" onclick="dismissPreProdBanner()" aria-label="Close banner">×</button>
   </div>
@@ -725,6 +752,8 @@ function dismissPreProdBanner() {
   <div class="nav-menu" id="navMenu">
     <a href="#" class="nav-link" onclick="openTeaser();return false;" style="color:#F7931A;border-bottom:1px solid rgba(247,147,26,0.4);padding-bottom:1px;">TEASER</a>
     <a href="photobook.html" class="nav-link"><span class="th-only">หนัง / สื่อ / ภาพ</span><span class="en-only">SATOSHI.MEDIA</span></a>
+    <a href="support.html" class="nav-link"><span class="th-only">สนับสนุนฉบับเต็ม</span><span class="en-only">SUPPORT</span></a>
+    <a href="press.html" class="nav-link"><span class="th-only">ข้อมูลสื่อ — PRESS</span><span class="en-only">PRESS KIT</span></a>
     <a href="https://app.gitbook.com/invite/CC1p6uOmzX05YyLDPevJ/r3fCPzAmLSaX2XHCIdgr" target="_blank" class="nav-link th-only">ร่วมพัฒนาบทภาพยนตร์และสารคดี</a>
     <a href="https://app.gitbook.com/invite/CC1p6uOmzX05YyLDPevJ/r3fCPzAmLSaX2XHCIdgr" target="_blank" class="nav-link en-only">SCRIPT & DOC COLLAB</a>
     <a href="https://github.com/sootisooti/satoshi.film" target="_blank" class="nav-link th-only">ร่วมพัฒนาเว็ปไซต์ SATOSHi</a>
@@ -753,6 +782,41 @@ function dismissPreProdBanner() {
   </div>
   <h1 class="hero-title">SATOSHi</h1>
   <div class="hero-title-th">ซ า โ ต ชิ</div>
+  <a href="#bff" class="hero-laurel" style="color:#F7F3E8;" aria-label="Official Selection — Bitcoin FilmFest 2026, Warsaw">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 300" role="img">
+      <defs>
+        <path id="heroLeaf" d="M0 0 C 5.5 -9 6.5 -21 0 -34 C -6.5 -21 -5.5 -9 0 0 Z"/>
+        <g id="heroBranch">
+          <path d="M337.9 275.7 L319.3 277.4 L300.5 278.0 L281.8 277.5 L263.1 275.8 L244.8 273.1 L226.9 269.3 L209.5 264.5 L192.8 258.6 L176.8 251.8 L161.8 244.0 L147.8 235.4 L135.0 226.0 L123.3 215.9 L113.0 205.1 L104.1 193.8 L96.6 181.9 L90.6 169.7 L86.2 157.1 L83.3 144.4 L82.1 131.5 L82.4 118.6 L84.4 105.7 L88.0 93.1 L93.1 80.7 L99.8 68.6 L108.0 57.0 L117.6 45.9 L128.5 35.4 L140.7 25.6 L154.1 16.5" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+          <use href="#heroLeaf" transform="translate(337.9 275.7) rotate(-122.9) scale(1.05)"/>
+          <use href="#heroLeaf" transform="translate(300.5 278.0) rotate(-64.1) scale(1.02)"/>
+          <use href="#heroLeaf" transform="translate(263.1 275.8) rotate(-109.3) scale(0.99)"/>
+          <use href="#heroLeaf" transform="translate(226.9 269.3) rotate(-50.2) scale(0.96)"/>
+          <use href="#heroLeaf" transform="translate(192.8 258.6) rotate(-94.8) scale(0.93)"/>
+          <use href="#heroLeaf" transform="translate(161.8 244.0) rotate(-34.6) scale(0.90)"/>
+          <use href="#heroLeaf" transform="translate(135.0 226.0) rotate(-77.4) scale(0.87)"/>
+          <use href="#heroLeaf" transform="translate(113.0 205.1) rotate(-15.1) scale(0.84)"/>
+          <use href="#heroLeaf" transform="translate(96.6 181.9) rotate(-55.2) scale(0.81)"/>
+          <use href="#heroLeaf" transform="translate(86.2 157.1) rotate(9.9) scale(0.78)"/>
+          <use href="#heroLeaf" transform="translate(82.1 131.5) rotate(-27.9) scale(0.75)"/>
+          <use href="#heroLeaf" transform="translate(84.4 105.7) rotate(38.3) scale(0.72)"/>
+          <use href="#heroLeaf" transform="translate(93.1 80.7) rotate(-0.2) scale(0.69)"/>
+          <use href="#heroLeaf" transform="translate(108.0 57.0) rotate(64.0) scale(0.66)"/>
+          <use href="#heroLeaf" transform="translate(128.5 35.4) rotate(22.8) scale(0.63)"/>
+          <use href="#heroLeaf" transform="translate(154.1 16.5) rotate(58.2) scale(0.60)"/>
+        </g>
+      </defs>
+      <g fill="currentColor">
+        <use href="#heroBranch"/>
+        <use href="#heroBranch" transform="translate(600 0) scale(-1 1)"/>
+      </g>
+      <g fill="currentColor" text-anchor="middle" font-family="'Space Mono','Courier New',monospace">
+        <text x="300" y="106" font-size="20" letter-spacing="5">OFFICIAL SELECTION</text>
+        <text x="300" y="152" font-size="30" font-weight="700" letter-spacing="1">BITCOIN FILMFEST</text>
+        <text x="300" y="194" font-size="19" letter-spacing="6">2026 · WARSAW</text>
+      </g>
+    </svg>
+  </a>
   <div class="hero-premise">
     <p class="th-only">คนหนึ่งคน<br>กับคอมหนึ่งเครื่อง<br>จะเปลี่ยนอะไรในโลกได้</p>
     <p class="en-only">One person.<br>One computer.<br>What in the world can it change.</p>
@@ -778,16 +842,34 @@ function dismissPreProdBanner() {
   <div class="bff-section-inner">
     <div class="bff-section-tag">OFFICIAL SELECTION</div>
     <div class="bff-section-title">BITCOIN FILM <span>FEST</span></div>
-    <div class="bff-section-year">2 0 2 6</div>
+    <div class="bff-section-year">2 0 2 6 — WARSAW</div>
     <div class="bff-section-divider"></div>
     <div class="bff-section-desc">
-      <span class="th-only">SATOSHI.FILM ได้รับการส่งเข้าร่วมงาน <strong>Bitcoin Film Fest 2026</strong> — เทศกาลภาพยนตร์นานาชาติที่อุทิศให้กับเรื่องราวของ Bitcoin ความจริง และอิสรภาพทางการเงิน เปิดรับผลงานจากผู้สร้างภาพยนตร์อิสระทั่วโลก</span>
-      <span class="en-only">SATOSHI.FILM has been submitted to <strong>Bitcoin Film Fest 2026</strong> — an international festival dedicated to Bitcoin, truth, and financial freedom. Celebrating independent filmmakers from across the world.</span>
+      <span class="th-only">SATOSHI ได้รับคัดเลือกอย่างเป็นทางการ และฉายแล้วที่ <strong>Bitcoin FilmFest 2026</strong> กรุงวอร์ซอ ในบล็อกภาพยนตร์ <strong>"Changing minds with fiction"</strong> — เทศกาลภาพยนตร์นานาชาติที่อุทิศให้กับเรื่องราวของ Bitcoin ความจริง และอิสรภาพทางการเงิน ขณะนี้กำลังระดมทุนเพื่อสร้างภาพยนตร์ฉบับเต็ม</span>
+      <span class="en-only">SATOSHI is an Official Selection of <strong>Bitcoin FilmFest 2026</strong>, Warsaw — screened in the festival's <strong>"Changing minds with fiction"</strong> block. The festival is dedicated to Bitcoin, truth, and financial freedom. The film is now raising support for the full feature.</span>
     </div>
-    <a href="#" class="bff-section-cta" onclick="openTeaser();return false;">
-      <span class="th-only">ดูตัวอย่างภาพยนตร์ →</span>
-      <span class="en-only">WATCH TEASER →</span>
-    </a>
+    <div class="screenings" id="screenings">
+      <div class="screenings-label">SCREENINGS</div>
+      <div class="screening-row">
+        <span class="screening-date">JUNE 2026</span>
+        <span class="screening-venue">BITCOIN FILMFEST 2026 — WARSAW, POLAND</span>
+        <span class="screening-detail">
+          <span class="th-only">บล็อก "Changing minds with fiction" — ช่วงภาพยนตร์ fiction คืนวันศุกร์ (prime-time)</span>
+          <span class="en-only">"Changing minds with fiction" block — Friday 18:00 prime-time fiction slot</span>
+        </span>
+        <a href="https://bitcoinfilmfest.com/bff26/" target="_blank" rel="noopener" class="screening-link">SOURCE: bitcoinfilmfest.com/bff26 ↗</a>
+      </div>
+    </div>
+    <div class="bff-section-ctas">
+      <a href="#" class="bff-section-cta" onclick="openTeaser();return false;">
+        <span class="th-only">ดูตัวอย่างภาพยนตร์ →</span>
+        <span class="en-only">WATCH TEASER →</span>
+      </a>
+      <a href="press.html" class="bff-section-cta cta-orange">
+        <span class="th-only">PRESS KIT →</span>
+        <span class="en-only">PRESS KIT →</span>
+      </a>
+    </div>
   </div>
 </section>
 
@@ -795,14 +877,21 @@ function dismissPreProdBanner() {
 
 <section class="worlds reveal" id="worlds">
   <div class="section-header">
-    <div class="section-header-label"><span class="th-only">สามโลก — THREE WORLDS</span><span class="en-only">THREE WORLDS — สามโลก</span></div>
+    <div class="section-header-label"><span class="th-only">เส้นเวลา — ความจริง → อดีต → ปัจจุบัน → อนาคต</span><span class="en-only">TIMELINE — TRUTH → PAST → PRESENT → FUTURE</span></div>
     <div class="section-header-title th-only">ทุกคนทำสิ่งที่ถูกต้องในยุคของตัวเอง</div>
     <div class="section-header-title en-only">Everyone did the right thing in their own era.</div>
   </div>
   <div class="worlds-grid">
     <div class="world-card reveal">
+      <div class="world-card-era">EVERY BLOCK</div>
+      <div class="world-card-title-th th-only">ความจริง</div>
+      <div class="world-card-title-th en-only">Truth</div>
+      <div class="world-card-title-en">DON'T TRUST — VERIFY</div>
+      <p class="world-card-desc th-only">ความจริงไม่ขึ้นอยู่กับว่าใครเป็นคนพูด แต่ขึ้นอยู่กับว่าใครตรวจสอบได้ ครอบครัวหนึ่งส่งต่อทั้งหนี้และความหวังจากรุ่นสู่รุ่น — และคำถามเดียวที่ยังค้างอยู่: อะไรคือสิ่งที่จริง</p>
+      <p class="world-card-desc en-only">Truth doesn't depend on who says it — it depends on who can verify it. One family passes down debt and hope across generations, and one question remains: what is real?</p>
+    </div>
+    <div class="world-card reveal">
       <div class="world-card-era">BEFORE BLOCK 0</div>
-      <div class="world-card-label">WORLD A</div>
       <div class="world-card-title-th th-only">อดีต</div>
       <div class="world-card-title-th en-only">The Past</div>
       <div class="world-card-title-en">FIAT WORLD</div>
@@ -811,7 +900,6 @@ function dismissPreProdBanner() {
     </div>
     <div class="world-card reveal">
       <div class="world-card-era">BLOCK 0 — PRESENT</div>
-      <div class="world-card-label">WORLD B</div>
       <div class="world-card-title-th th-only">ปัจจุบัน</div>
       <div class="world-card-title-th en-only">The Present</div>
       <div class="world-card-title-en">TRANSITION</div>
@@ -820,7 +908,6 @@ function dismissPreProdBanner() {
     </div>
     <div class="world-card world-c reveal">
       <div class="world-card-era">BITCOIN STANDARD ERA</div>
-      <div class="world-card-label">WORLD C</div>
       <div class="world-card-title-th th-only">อนาคต</div>
       <div class="world-card-title-th en-only">The Future</div>
       <div class="world-card-title-en">AFTER TRANSITION</div>
@@ -1801,6 +1888,13 @@ function dismissPreProdBanner() {
       <button class="tier-btn" onclick="openZapModal('BLOCK')">⚡ ZAP</button>
     </div>
   </div>
+  <div class="reveal" style="text-align:center; margin-top:48px;">
+    <p style="font-family:'Sarabun',sans-serif; font-size:14px; line-height:1.8; color:#666660; max-width:560px; margin:0 auto 20px;">
+      <span class="th-only">เรากำลังระดมทุนสร้างภาพยนตร์ฉบับเต็ม — ดูช่องทางสนับสนุนทั้งหมด และช่องทางติดต่อสำหรับผู้ลงทุน/สปอนเซอร์</span>
+      <span class="en-only">We are raising support for the full feature — see all funding channels and the contact for investors &amp; sponsors.</span>
+    </p>
+    <a href="support.html" style="font-family:'Space Mono',monospace;font-size:11px;letter-spacing:3px;color:#F7931A;border:1px solid rgba(247,147,26,0.4);padding:14px 32px;text-decoration:none;display:inline-block;transition:all 0.3s;" onmouseenter="this.style.background='rgba(247,147,26,0.08)';this.style.borderColor='#F7931A';" onmouseleave="this.style.background='';this.style.borderColor='rgba(247,147,26,0.4)';"><span class="th-only">สนับสนุนฉบับเต็ม →</span><span class="en-only">FUND THE FEATURE →</span></a>
+  </div>
 </section>
 
 <section class="forum" id="forum" style="padding: 80px 40px; text-align: center;">
@@ -1822,6 +1916,10 @@ function dismissPreProdBanner() {
       <a href="https://app.gitbook.com/invite/CC1p6uOmzX05YyLDPevJ/r3fCPzAmLSaX2XHCIdgr" target="_blank" class="en-only">SCRIPT &amp; DOC COLLAB</a>
       <a href="https://github.com/sootisooti/satoshi.film" target="_blank" class="th-only">ร่วมพัฒนาเว็บไซต์</a>
       <a href="https://github.com/sootisooti/satoshi.film" target="_blank" class="en-only">WEBSITE COLLAB</a>
+      <a href="support.html" class="th-only">สนับสนุนฉบับเต็ม</a>
+      <a href="support.html" class="en-only">SUPPORT</a>
+      <a href="press.html" class="th-only">PRESS KIT</a>
+      <a href="press.html" class="en-only">PRESS KIT</a>
       <a href="#" onclick="toggleLang(); return false;" style="margin-left: 20px;">
         <span>EN / TH</span>
       </a>

--- a/photobook.html
+++ b/photobook.html
@@ -156,8 +156,8 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
 <div id="preProdBanner" class="preprod-banner">
   <div class="preprod-content">
     <span class="preprod-text">
-      <span>ฉายแล้วที่ Bitcoin FilmFest 2026 วอร์ซอ — กำลังระดมทุนสร้างฉบับเต็ม · ขออภัยหาก feature บางส่วนยังไม่ทำงาน</span>
-      <span>Screened at Bitcoin FilmFest 2026, Warsaw — now raising the full feature · Apologies if some features don't work yet</span>
+      <span>Teaser ฉายแล้วที่ Bitcoin FilmFest 2026 วอร์ซอ — กำลังระดมทุนสร้างฉบับเต็ม · ขออภัยหาก feature บางส่วนยังไม่ทำงาน</span>
+      <span>Teaser screened at Bitcoin FilmFest 2026, Warsaw — now raising the full feature · Apologies if some features don't work yet</span>
     </span>
     <button class="preprod-close" onclick="dismissPreProdBanner()" aria-label="Close banner">×</button>
   </div>

--- a/press.html
+++ b/press.html
@@ -187,27 +187,48 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
   <h1 class="pk-title reveal">SATOSHI <span>— ซาโตชิ</span></h1>
 
   <div class="pk-laurel reveal" aria-label="Official Selection — Bitcoin FilmFest 2026, Warsaw">
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 300" role="img">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 300" role="img" shape-rendering="crispEdges">
       <defs>
-        <path id="pkLeaf" d="M0 0 C 5.5 -9 6.5 -21 0 -34 C -6.5 -21 -5.5 -9 0 0 Z"/>
         <g id="pkBranch">
-          <path d="M337.9 275.7 L319.3 277.4 L300.5 278.0 L281.8 277.5 L263.1 275.8 L244.8 273.1 L226.9 269.3 L209.5 264.5 L192.8 258.6 L176.8 251.8 L161.8 244.0 L147.8 235.4 L135.0 226.0 L123.3 215.9 L113.0 205.1 L104.1 193.8 L96.6 181.9 L90.6 169.7 L86.2 157.1 L83.3 144.4 L82.1 131.5 L82.4 118.6 L84.4 105.7 L88.0 93.1 L93.1 80.7 L99.8 68.6 L108.0 57.0 L117.6 45.9 L128.5 35.4 L140.7 25.6 L154.1 16.5" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
-          <use href="#pkLeaf" transform="translate(337.9 275.7) rotate(-122.9) scale(1.05)"/>
-          <use href="#pkLeaf" transform="translate(300.5 278.0) rotate(-64.1) scale(1.02)"/>
-          <use href="#pkLeaf" transform="translate(263.1 275.8) rotate(-109.3) scale(0.99)"/>
-          <use href="#pkLeaf" transform="translate(226.9 269.3) rotate(-50.2) scale(0.96)"/>
-          <use href="#pkLeaf" transform="translate(192.8 258.6) rotate(-94.8) scale(0.93)"/>
-          <use href="#pkLeaf" transform="translate(161.8 244.0) rotate(-34.6) scale(0.90)"/>
-          <use href="#pkLeaf" transform="translate(135.0 226.0) rotate(-77.4) scale(0.87)"/>
-          <use href="#pkLeaf" transform="translate(113.0 205.1) rotate(-15.1) scale(0.84)"/>
-          <use href="#pkLeaf" transform="translate(96.6 181.9) rotate(-55.2) scale(0.81)"/>
-          <use href="#pkLeaf" transform="translate(86.2 157.1) rotate(9.9) scale(0.78)"/>
-          <use href="#pkLeaf" transform="translate(82.1 131.5) rotate(-27.9) scale(0.75)"/>
-          <use href="#pkLeaf" transform="translate(84.4 105.7) rotate(38.3) scale(0.72)"/>
-          <use href="#pkLeaf" transform="translate(93.1 80.7) rotate(-0.2) scale(0.69)"/>
-          <use href="#pkLeaf" transform="translate(108.0 57.0) rotate(64.0) scale(0.66)"/>
-          <use href="#pkLeaf" transform="translate(128.5 35.4) rotate(22.8) scale(0.63)"/>
-          <use href="#pkLeaf" transform="translate(154.1 16.5) rotate(58.2) scale(0.60)"/>
+          <rect x="160" y="0" width="10" height="10"/>
+          <rect x="180" y="0" width="10" height="10"/>
+          <rect x="140" y="10" width="20" height="10"/>
+          <rect x="110" y="20" width="40" height="10"/>
+          <rect x="110" y="30" width="30" height="10"/>
+          <rect x="110" y="40" width="30" height="10"/>
+          <rect x="70" y="50" width="10" height="10"/>
+          <rect x="90" y="50" width="30" height="10"/>
+          <rect x="80" y="60" width="40" height="10"/>
+          <rect x="90" y="70" width="30" height="10"/>
+          <rect x="80" y="80" width="20" height="10"/>
+          <rect x="60" y="90" width="50" height="10"/>
+          <rect x="70" y="100" width="30" height="10"/>
+          <rect x="80" y="110" width="10" height="10"/>
+          <rect x="80" y="120" width="10" height="10"/>
+          <rect x="80" y="130" width="10" height="10"/>
+          <rect x="80" y="140" width="30" height="10"/>
+          <rect x="70" y="150" width="30" height="10"/>
+          <rect x="60" y="160" width="40" height="10"/>
+          <rect x="90" y="170" width="20" height="10"/>
+          <rect x="120" y="170" width="10" height="10"/>
+          <rect x="80" y="180" width="40" height="10"/>
+          <rect x="80" y="190" width="30" height="10"/>
+          <rect x="100" y="200" width="30" height="10"/>
+          <rect x="100" y="210" width="30" height="10"/>
+          <rect x="100" y="220" width="60" height="10"/>
+          <rect x="140" y="230" width="20" height="10"/>
+          <rect x="190" y="230" width="10" height="10"/>
+          <rect x="130" y="240" width="10" height="10"/>
+          <rect x="150" y="240" width="50" height="10"/>
+          <rect x="140" y="250" width="10" height="10"/>
+          <rect x="170" y="250" width="30" height="10"/>
+          <rect x="230" y="250" width="10" height="10"/>
+          <rect x="130" y="260" width="10" height="10"/>
+          <rect x="170" y="260" width="70" height="10"/>
+          <rect x="170" y="270" width="10" height="10"/>
+          <rect x="230" y="270" width="80" height="10"/>
+          <rect x="210" y="280" width="20" height="10"/>
+          <rect x="210" y="290" width="10" height="10"/>
         </g>
       </defs>
       <g fill="currentColor">

--- a/press.html
+++ b/press.html
@@ -229,7 +229,7 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
       <li><span class="k">FORMAT</span><span class="v"><span class="en-only">Feature film — family drama</span><span class="th-only">ภาพยนตร์ขนาดยาว — ดราม่าครอบครัว</span></span></li>
       <li><span class="k">COUNTRY</span><span class="v"><span class="en-only">Thailand</span><span class="th-only">ประเทศไทย</span></span></li>
       <li><span class="k">LANGUAGE</span><span class="v"><span class="en-only">Thai, with English subtitles</span><span class="th-only">ไทย (ซับไตเติลอังกฤษ)</span></span></li>
-      <li><span class="k">FESTIVAL</span><span class="v">Official Selection — Bitcoin FilmFest 2026, Warsaw</span></li>
+      <li><span class="k">FESTIVAL</span><span class="v">Official Selection — Bitcoin FilmFest 2026, Warsaw (official teaser screened)</span></li>
       <li><span class="k">STATUS</span><span class="v"><span class="en-only">Feature in development — screenplay in active rewrite, raising production funding</span><span class="th-only">อยู่ระหว่างพัฒนาฉบับเต็ม — บทกำลัง rewrite และกำลังระดมทุนสร้าง</span></span></li>
       <li><span class="k">TEASER</span><span class="v"><a href="https://www.youtube.com/watch?v=JxJdUSh11_o" target="_blank" rel="noopener">youtube.com/watch?v=JxJdUSh11_o ↗</a></span></li>
       <li><span class="k">CONTACT</span><span class="v"><a href="mailto:satoshi21film@gmail.com">satoshi21film@gmail.com</a></span></li>
@@ -302,7 +302,7 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
     <div class="pk-label green">FESTIVAL</div>
     <div class="pk-festival">
       <span class="f1">★ OFFICIAL SELECTION — BITCOIN FILMFEST 2026, WARSAW</span>
-      <span class="f2"><span class="en-only">Screened in the <strong>"Changing minds with fiction"</strong> block — the festival's Friday 18:00 prime-time fiction slot, June 2026, Warsaw, Poland.</span><span class="th-only">ฉายในบล็อก <strong>"Changing minds with fiction"</strong> — ช่วงภาพยนตร์ fiction คืนวันศุกร์ 18:00 (prime-time) มิถุนายน 2026 กรุงวอร์ซอ โปแลนด์</span></span>
+      <span class="f2"><span class="en-only">The <strong>official teaser</strong> screened in the <strong>"Changing minds with fiction"</strong> block — the festival's Friday 18:00 prime-time fiction slot, June 2026, Warsaw, Poland. The teaser alone earned the slot; the feature is now in development.</span><span class="th-only"><strong>Teaser อย่างเป็นทางการ</strong>ฉายในบล็อก <strong>"Changing minds with fiction"</strong> — ช่วงภาพยนตร์ fiction คืนวันศุกร์ 18:00 (prime-time) มิถุนายน 2026 กรุงวอร์ซอ โปแลนด์ — แค่ teaser ก็ได้ slot นี้มาแล้ว ฉบับเต็มกำลังอยู่ระหว่างพัฒนา</span></span>
       <a href="https://bitcoinfilmfest.com/bff26/" target="_blank" rel="noopener" class="pk-link">SOURCE: bitcoinfilmfest.com/bff26 ↗</a>
     </div>
   </div>

--- a/press.html
+++ b/press.html
@@ -1,0 +1,446 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PRESS KIT — SATOSHI | Official Selection — Bitcoin FilmFest 2026, Warsaw</title>
+<meta name="description" content="Press kit for SATOSHI — a Thai family drama about debt, fiat money, and truth across four generations. Logline, synopsis, teaser, key art, and festival credit. Official Selection — Bitcoin FilmFest 2026, Warsaw.">
+<link rel="canonical" href="https://sootisooti.github.io/satoshi.film/press.html">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="SATOSHI.FILM">
+<meta property="og:title" content="PRESS KIT — SATOSHI">
+<meta property="og:description" content="Logline, synopsis, teaser, key art, and festival credit for SATOSHI. Official Selection — Bitcoin FilmFest 2026, Warsaw.">
+<meta property="og:url" content="https://sootisooti.github.io/satoshi.film/press.html">
+<meta property="og:image" content="https://sootisooti.github.io/satoshi.film/assets/posters/poster-01.jpg">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="PRESS KIT — SATOSHI">
+<meta name="twitter:description" content="Official Selection — Bitcoin FilmFest 2026, Warsaw.">
+<meta name="twitter:image" content="https://sootisooti.github.io/satoshi.film/assets/posters/poster-01.jpg">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Mono:ital,wght@0,400;0,700;1,400&family=Noto+Serif+Thai:wght@400;700&family=Sarabun:wght@300;400;600;700&display=swap" rel="stylesheet">
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+::selection { background: #F7931A; color: #080806; }
+html { scroll-behavior: smooth; background: #080806; }
+body { font-family: 'Sarabun', sans-serif; background: #080806; color: #d4d0c8; overflow-x: hidden; cursor: none; }
+body.lang-th .en-only { display: none !important; }
+body.lang-en .th-only { display: none !important; }
+
+/* Custom Cursor */
+.cursor-dot { width: 8px; height: 8px; background: #F7931A; border-radius: 50%; position: fixed; pointer-events: none; z-index: 99999; transition: transform 0.1s; mix-blend-mode: difference; }
+.cursor-ring { width: 32px; height: 32px; border: 1.5px solid #F7931A; border-radius: 50%; position: fixed; pointer-events: none; z-index: 99998; transition: transform 0.15s ease-out, width 0.2s, height 0.2s, border-color 0.2s; transform: translate(-12px, -12px); }
+.cursor-ring.hovering { width: 48px; height: 48px; border-color: #00FF41; transform: translate(-20px, -20px); }
+
+/* Nav */
+nav { position: fixed; top: 0; left: 0; right: 0; z-index: 1000; display: grid; grid-template-columns: auto 1fr auto; align-items: center; gap: 16px; padding: 20px 40px; background: linear-gradient(180deg, #080806 60%, transparent); backdrop-filter: blur(4px); }
+.nav-logo { font-family: 'Space Mono', monospace; font-size: 14px; letter-spacing: 6px; color: #F7931A; text-decoration: none; display: flex; align-items: center; }
+.nav-page-label { font-size: 9px; color: #666660; letter-spacing: 2px; opacity: 0.6; margin-left: 8px; padding-left: 8px; border-left: 1px solid rgba(102,102,96,0.3); }
+.nav-menu { display: flex; gap: 24px; justify-content: center; min-width: 0; flex-wrap: wrap; row-gap: 6px; }
+.nav-link { font-family: 'Space Mono', monospace; font-size: 10px; color: #666660; text-decoration: none; letter-spacing: 1px; transition: color 0.3s; white-space: nowrap; }
+.nav-link:hover { color: #F7931A; }
+.nav-right { display: flex; align-items: center; gap: 12px; flex-shrink: 0; }
+.lang-toggle { font-family: 'Space Mono', monospace; font-size: 12px; letter-spacing: 2px; color: #666660; border: 1px solid #666660; padding: 6px 14px; background: transparent; cursor: none; transition: all 0.3s; }
+.lang-toggle:hover { color: #F7931A; border-color: #F7931A; }
+.nav-action-btn { font-family: 'Space Mono', monospace; font-size: 0.7rem; text-decoration: none; letter-spacing: 0.15em; padding: 6px 14px; transition: background 0.2s, box-shadow 0.2s; display: inline-block; }
+.nav-zap-btn { color: #F7931A; border: 1px solid rgba(247,147,26,0.5); }
+.nav-zap-btn:hover { background: rgba(247,147,26,0.12); box-shadow: 0 0 10px rgba(247,147,26,0.25); }
+
+/* Press Page */
+.pk-page { padding: 150px 40px 100px; max-width: 880px; margin: 0 auto; }
+.pk-eyebrow { font-family: 'Space Mono', monospace; font-size: 10px; letter-spacing: 4px; color: #666660; margin-bottom: 16px; text-align: center; }
+.pk-title { font-family: 'Space Mono', monospace; font-size: clamp(28px, 6vw, 56px); font-weight: 700; letter-spacing: 0.06em; color: #d4d0c8; text-align: center; line-height: 1.15; }
+.pk-title span { color: #F7931A; }
+.pk-laurel { display: block; width: min(340px, 80vw); margin: 44px auto 0; color: #F7F3E8; opacity: 0.92; }
+.pk-laurel svg { width: 100%; height: auto; display: block; }
+.pk-block { margin-top: 80px; }
+.pk-label { font-family: 'Space Mono', monospace; font-size: 10px; letter-spacing: 5px; color: #F7931A; margin-bottom: 24px; }
+.pk-label.green { color: #00FF41; }
+.pk-facts { list-style: none; }
+.pk-facts li { display: flex; gap: 18px; padding: 13px 0; border-bottom: 1px solid rgba(255,255,255,0.05); align-items: baseline; }
+.pk-facts .k { font-family: 'Space Mono', monospace; font-size: 10px; letter-spacing: 2px; color: #666660; min-width: 130px; white-space: nowrap; }
+.pk-facts .v { font-family: 'Sarabun', sans-serif; font-size: 15px; color: #d4d0c8; }
+.pk-facts .v a { color: #00FF41; text-decoration: none; transition: color 0.3s; }
+.pk-facts .v a:hover { color: #F7931A; }
+.pk-logline { font-family: 'Sarabun', sans-serif; font-size: 19px; line-height: 1.9; color: #d4d0c8; border-left: 2px solid #F7931A; padding: 4px 0 4px 24px; max-width: 700px; }
+.pk-logline + .pk-logline { margin-top: 20px; }
+.pk-text { font-family: 'Sarabun', sans-serif; font-size: 15px; line-height: 1.95; color: #8a877e; max-width: 700px; }
+.pk-text + .pk-text { margin-top: 14px; }
+.pk-text strong { color: #d4d0c8; font-weight: 600; }
+.pk-phase { display: flex; gap: 20px; padding: 20px 0; border-bottom: 1px solid rgba(255,255,255,0.05); align-items: baseline; max-width: 700px; }
+.pk-phase .ph { font-family: 'Space Mono', monospace; font-size: 11px; letter-spacing: 2px; color: #F7931A; min-width: 110px; white-space: nowrap; }
+.pk-phase .pd { font-family: 'Sarabun', sans-serif; font-size: 15px; line-height: 1.85; color: #8a877e; }
+.pk-note { font-family: 'Space Mono', monospace; font-size: 10px; letter-spacing: 1px; line-height: 2; color: #666660; margin-top: 28px; max-width: 700px; }
+.pk-video { position: relative; width: 100%; aspect-ratio: 16 / 9; background: #000; border: 1px solid rgba(255,255,255,0.08); margin-bottom: 16px; }
+.pk-video iframe { position: absolute; inset: 0; width: 100%; height: 100%; border: 0; }
+.pk-link { font-family: 'Space Mono', monospace; font-size: 11px; letter-spacing: 2px; color: #00FF41; text-decoration: none; transition: color 0.3s; }
+.pk-link:hover { color: #F7931A; }
+.pk-stills { display: grid; grid-template-columns: repeat(3, 1fr); gap: 2px; }
+.pk-still { position: relative; display: block; border: 1px solid rgba(255,255,255,0.04); }
+.pk-still img { width: 100%; display: block; filter: brightness(0.9); transition: filter 0.3s; cursor: pointer; }
+.pk-still img:hover { filter: brightness(1.05); }
+.pk-still-dl { display: block; text-align: center; font-family: 'Space Mono', monospace; font-size: 9px; letter-spacing: 2px; color: #666660; text-decoration: none; padding: 10px 0; transition: color 0.3s; }
+.pk-still-dl:hover { color: #F7931A; }
+.pk-festival { border: 1px solid rgba(0,255,65,0.15); background: rgba(0,255,65,0.02); padding: 32px; display: flex; flex-direction: column; gap: 10px; max-width: 700px; }
+.pk-festival .f1 { font-family: 'Space Mono', monospace; font-size: 13px; letter-spacing: 2px; color: #00FF41; }
+.pk-festival .f2 { font-family: 'Sarabun', sans-serif; font-size: 14px; line-height: 1.8; color: #8a877e; }
+.pk-dl-list { list-style: none; }
+.pk-dl-list li { padding: 12px 0; border-bottom: 1px solid rgba(255,255,255,0.05); }
+.pk-dl-list a { font-family: 'Space Mono', monospace; font-size: 12px; letter-spacing: 1px; color: #00FF41; text-decoration: none; transition: color 0.3s; }
+.pk-dl-list a:hover { color: #F7931A; }
+.pk-dl-list .sz { font-family: 'Space Mono', monospace; font-size: 10px; color: #666660; margin-left: 10px; }
+.pk-contact { text-align: center; border: 1px solid rgba(247,147,26,0.2); background: rgba(247,147,26,0.02); padding: 44px 32px; }
+.pk-contact .c1 { font-family: 'Space Mono', monospace; font-size: 10px; letter-spacing: 5px; color: #F7931A; margin-bottom: 18px; }
+.pk-contact .c2 { font-family: 'Space Mono', monospace; font-size: clamp(14px, 3.4vw, 22px); color: #d4d0c8; word-break: break-all; }
+.pk-contact .c2 a { color: inherit; text-decoration: none; transition: color 0.3s; }
+.pk-contact .c2 a:hover { color: #00FF41; }
+.pk-contact .c3 { font-family: 'Sarabun', sans-serif; font-size: 13px; color: #666660; margin-top: 14px; }
+.pk-footer-links { margin-top: 72px; display: flex; justify-content: center; gap: 28px; flex-wrap: wrap; }
+.pk-footer-links a { font-family: 'Space Mono', monospace; font-size: 10px; letter-spacing: 2px; color: #666660; text-decoration: none; transition: color 0.3s; }
+.pk-footer-links a:hover { color: #F7931A; }
+
+/* Lightbox */
+.lightbox-overlay { position: fixed; inset: 0; background: rgba(8,8,6,0.97); z-index: 20000; display: none; align-items: center; justify-content: center; cursor: pointer; }
+.lightbox-overlay.active { display: flex; }
+.lightbox-img { max-width: 90vw; max-height: 90vh; object-fit: contain; display: block; cursor: default; }
+.lightbox-close { position: fixed; top: 24px; right: 28px; font-size: 28px; color: #666660; background: none; border: none; cursor: pointer; transition: color 0.2s; font-family: 'Space Mono', monospace; z-index: 20001; line-height: 1; }
+.lightbox-close:hover { color: #F7931A; }
+
+/* Footer */
+footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); }
+.footer-content { text-align: center; }
+.footer-logo { font-family: 'Space Mono', monospace; font-size: 13px; letter-spacing: 6px; color: #F7931A; margin-bottom: 12px; }
+.footer-copy { font-family: 'Space Mono', monospace; font-size: 10px; color: #666660; letter-spacing: 2px; margin-bottom: 16px; }
+.footer-links { display: flex; justify-content: center; flex-wrap: wrap; gap: 24px; }
+.footer-links a { font-family: 'Space Mono', monospace; font-size: 10px; letter-spacing: 2px; color: #666660; text-decoration: none; transition: color 0.3s; }
+.footer-links a:hover { color: #F7931A; }
+
+/* Scroll Reveal */
+.reveal { opacity: 0; transform: translateY(30px); transition: opacity 0.8s, transform 0.8s; }
+.reveal.visible { opacity: 1; transform: translateY(0); }
+
+/* Back to Top */
+.back-to-top { position: fixed; bottom: 32px; right: 32px; width: 44px; height: 44px; background: rgba(8,8,6,0.85); border: 1px solid rgba(247,147,26,0.3); color: #F7931A; font-family: 'Space Mono', monospace; font-size: 16px; cursor: none; opacity: 0; pointer-events: none; transition: opacity 0.3s, border-color 0.3s, background 0.3s; z-index: 499; display: flex; align-items: center; justify-content: center; line-height: 1; }
+.back-to-top.visible { opacity: 1; pointer-events: all; }
+.back-to-top:hover { border-color: #F7931A; background: rgba(247,147,26,0.1); }
+
+/* Mobile Nav */
+@media (max-width: 1200px) { nav { padding: 18px 24px; gap: 12px; } .nav-menu { gap: 14px; } .nav-link { font-size: 9px; letter-spacing: 0.5px; } }
+@media (max-width: 900px) { nav { grid-template-columns: auto 1fr; padding: 16px 20px; gap: 12px; } .nav-menu { gap: 12px 8px; justify-content: flex-start; } .nav-right { grid-column: 1 / -1; justify-content: flex-end; margin-top: 4px; } }
+.nav-hamburger { display: none; flex-direction: column; justify-content: center; gap: 5px; width: 44px; height: 44px; background: transparent; border: none; cursor: none; padding: 0 10px; flex-shrink: 0; }
+.nav-hamburger span { display: block; width: 20px; height: 1.5px; background: #d4d0c8; transition: all 0.3s; }
+.nav-hamburger.open span:nth-child(1) { transform: translateY(6.5px) rotate(45deg); }
+.nav-hamburger.open span:nth-child(2) { opacity: 0; }
+.nav-hamburger.open span:nth-child(3) { transform: translateY(-6.5px) rotate(-45deg); }
+.mobile-only { display: none !important; }
+.nav-mobile-divider { width: 100%; height: 1px; background: rgba(247,147,26,0.15); margin: 8px 0; }
+
+@media (max-width: 640px) {
+  .nav-hamburger { display: flex; }
+  .mobile-only { display: block !important; }
+  nav { grid-template-columns: auto 1fr auto; }
+  .nav-right { grid-column: auto; margin-top: 0; gap: 4px; }
+  .nav-menu { display: none; position: absolute; top: 100%; left: 0; right: 0; background: rgba(8,8,6,0.97); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border-top: 1px solid rgba(255,255,255,0.06); flex-direction: column; padding: 12px 24px 24px; gap: 0; z-index: 999; box-shadow: 0 24px 48px rgba(0,0,0,0.6); }
+  .nav-menu.mobile-open { display: flex; }
+  .nav-link { font-size: 12px; letter-spacing: 1px; padding: 14px 0; border-bottom: 1px solid rgba(255,255,255,0.05); color: #d4d0c8; width: 100%; }
+  .nav-link:last-of-type { border-bottom: none; }
+  .back-to-top { bottom: 20px; right: 16px; width: 40px; height: 40px; font-size: 14px; }
+  .pk-page { padding: 130px 20px 80px; }
+  .pk-stills { grid-template-columns: 1fr; }
+  .pk-phase { flex-direction: column; gap: 8px; }
+  .pk-facts li { flex-direction: column; gap: 4px; }
+  .pk-logline { font-size: 17px; }
+  .pk-festival { padding: 24px 20px; }
+}
+</style>
+</head>
+<body class="lang-en">
+
+<div class="cursor-dot" id="cursorDot"></div>
+<div class="cursor-ring" id="cursorRing"></div>
+
+<!-- Lightbox -->
+<div class="lightbox-overlay" id="lightboxOverlay" onclick="closeLightbox(event)">
+  <button class="lightbox-close" onclick="closeLightbox(null)" aria-label="Close lightbox">×</button>
+  <img class="lightbox-img" id="lightboxImg" src="" alt="SATOSHI key art" onclick="event.stopPropagation()">
+</div>
+
+<nav>
+  <a href="index.html" class="nav-logo">SATOSHi <span class="nav-page-label">PRESS</span></a>
+  <div class="nav-menu" id="navMenu">
+    <a href="index.html" class="nav-link"><span class="th-only">หน้าหลัก</span><span class="en-only">HOME</span></a>
+    <a href="support.html" class="nav-link"><span class="th-only">สนับสนุนฉบับเต็ม</span><span class="en-only">SUPPORT</span></a>
+    <a href="photobook.html" class="nav-link"><span class="th-only">หนัง / สื่อ / ภาพ</span><span class="en-only">SATOSHI.MEDIA</span></a>
+    <a href="https://github.com/sootisooti/satoshi.film" target="_blank" class="nav-link th-only">ร่วมพัฒนาเว็ปไซต์ SATOSHi</a>
+    <a href="https://github.com/sootisooti/satoshi.film" target="_blank" class="nav-link en-only">WEBSITE COLLAB</a>
+  </div>
+  <div class="nav-right">
+    <a href="support.html" class="nav-action-btn nav-zap-btn"><span class="th-only">⚡ สนับสนุน</span><span class="en-only">⚡ SUPPORT</span></a>
+    <button class="lang-toggle" onclick="toggleLang()"><span>EN / TH</span></button>
+    <button class="nav-hamburger" id="navHamburger" aria-label="Toggle navigation" onclick="toggleMobileNav()"><span></span><span></span><span></span></button>
+  </div>
+</nav>
+
+<main class="pk-page">
+
+  <div class="pk-eyebrow reveal">PRESS KIT — ข้อมูลสำหรับสื่อ</div>
+  <h1 class="pk-title reveal">SATOSHI <span>— ซาโตชิ</span></h1>
+
+  <div class="pk-laurel reveal" aria-label="Official Selection — Bitcoin FilmFest 2026, Warsaw">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 300" role="img">
+      <defs>
+        <path id="pkLeaf" d="M0 0 C 5.5 -9 6.5 -21 0 -34 C -6.5 -21 -5.5 -9 0 0 Z"/>
+        <g id="pkBranch">
+          <path d="M337.9 275.7 L319.3 277.4 L300.5 278.0 L281.8 277.5 L263.1 275.8 L244.8 273.1 L226.9 269.3 L209.5 264.5 L192.8 258.6 L176.8 251.8 L161.8 244.0 L147.8 235.4 L135.0 226.0 L123.3 215.9 L113.0 205.1 L104.1 193.8 L96.6 181.9 L90.6 169.7 L86.2 157.1 L83.3 144.4 L82.1 131.5 L82.4 118.6 L84.4 105.7 L88.0 93.1 L93.1 80.7 L99.8 68.6 L108.0 57.0 L117.6 45.9 L128.5 35.4 L140.7 25.6 L154.1 16.5" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+          <use href="#pkLeaf" transform="translate(337.9 275.7) rotate(-122.9) scale(1.05)"/>
+          <use href="#pkLeaf" transform="translate(300.5 278.0) rotate(-64.1) scale(1.02)"/>
+          <use href="#pkLeaf" transform="translate(263.1 275.8) rotate(-109.3) scale(0.99)"/>
+          <use href="#pkLeaf" transform="translate(226.9 269.3) rotate(-50.2) scale(0.96)"/>
+          <use href="#pkLeaf" transform="translate(192.8 258.6) rotate(-94.8) scale(0.93)"/>
+          <use href="#pkLeaf" transform="translate(161.8 244.0) rotate(-34.6) scale(0.90)"/>
+          <use href="#pkLeaf" transform="translate(135.0 226.0) rotate(-77.4) scale(0.87)"/>
+          <use href="#pkLeaf" transform="translate(113.0 205.1) rotate(-15.1) scale(0.84)"/>
+          <use href="#pkLeaf" transform="translate(96.6 181.9) rotate(-55.2) scale(0.81)"/>
+          <use href="#pkLeaf" transform="translate(86.2 157.1) rotate(9.9) scale(0.78)"/>
+          <use href="#pkLeaf" transform="translate(82.1 131.5) rotate(-27.9) scale(0.75)"/>
+          <use href="#pkLeaf" transform="translate(84.4 105.7) rotate(38.3) scale(0.72)"/>
+          <use href="#pkLeaf" transform="translate(93.1 80.7) rotate(-0.2) scale(0.69)"/>
+          <use href="#pkLeaf" transform="translate(108.0 57.0) rotate(64.0) scale(0.66)"/>
+          <use href="#pkLeaf" transform="translate(128.5 35.4) rotate(22.8) scale(0.63)"/>
+          <use href="#pkLeaf" transform="translate(154.1 16.5) rotate(58.2) scale(0.60)"/>
+        </g>
+      </defs>
+      <g fill="currentColor">
+        <use href="#pkBranch"/>
+        <use href="#pkBranch" transform="translate(600 0) scale(-1 1)"/>
+      </g>
+      <g fill="currentColor" text-anchor="middle" font-family="'Space Mono','Courier New',monospace">
+        <text x="300" y="106" font-size="20" letter-spacing="5">OFFICIAL SELECTION</text>
+        <text x="300" y="152" font-size="30" font-weight="700" letter-spacing="1">BITCOIN FILMFEST</text>
+        <text x="300" y="194" font-size="19" letter-spacing="6">2026 · WARSAW</text>
+      </g>
+    </svg>
+  </div>
+
+  <div class="pk-block reveal">
+    <div class="pk-label">FILM FACTS</div>
+    <ul class="pk-facts">
+      <li><span class="k">TITLE</span><span class="v">SATOSHI (ซาโตชิ)</span></li>
+      <li><span class="k">FORMAT</span><span class="v"><span class="en-only">Feature film — family drama</span><span class="th-only">ภาพยนตร์ขนาดยาว — ดราม่าครอบครัว</span></span></li>
+      <li><span class="k">COUNTRY</span><span class="v"><span class="en-only">Thailand</span><span class="th-only">ประเทศไทย</span></span></li>
+      <li><span class="k">LANGUAGE</span><span class="v"><span class="en-only">Thai, with English subtitles</span><span class="th-only">ไทย (ซับไตเติลอังกฤษ)</span></span></li>
+      <li><span class="k">FESTIVAL</span><span class="v">Official Selection — Bitcoin FilmFest 2026, Warsaw</span></li>
+      <li><span class="k">STATUS</span><span class="v"><span class="en-only">Feature in development — screenplay in active rewrite, raising production funding</span><span class="th-only">อยู่ระหว่างพัฒนาฉบับเต็ม — บทกำลัง rewrite และกำลังระดมทุนสร้าง</span></span></li>
+      <li><span class="k">TEASER</span><span class="v"><a href="https://www.youtube.com/watch?v=JxJdUSh11_o" target="_blank" rel="noopener">youtube.com/watch?v=JxJdUSh11_o ↗</a></span></li>
+      <li><span class="k">CONTACT</span><span class="v"><a href="mailto:satoshi21film@gmail.com">satoshi21film@gmail.com</a></span></li>
+    </ul>
+  </div>
+
+  <div class="pk-block reveal">
+    <div class="pk-label">LOGLINE</div>
+    <p class="pk-logline en-only">Across four generations, a Thai family inherits debt it never chose — and a question it can't escape: when money itself can be quietly rewritten, how do you prove what's true?</p>
+    <p class="pk-logline th-only">สี่รุ่นของครอบครัวไทยครอบครัวหนึ่ง รับมรดกเป็นหนี้ที่ตัวเองไม่ได้ก่อ — และคำถามที่หนีไม่พ้น: เมื่อเงินถูกแก้ไขอย่างเงียบ ๆ ได้ เราจะพิสูจน์ความจริงได้อย่างไร</p>
+  </div>
+
+  <div class="pk-block reveal">
+    <div class="pk-label">SYNOPSIS</div>
+    <p class="pk-text en-only"><strong>SATOSHI</strong> follows one ordinary Thai family across four generations — a story told along four movements in time.</p>
+    <p class="pk-text th-only"><strong>SATOSHI</strong> ติดตามครอบครัวไทยธรรมดาครอบครัวหนึ่งข้ามสี่รุ่น — เล่าตามเส้นเวลาสี่ช่วง</p>
+    <div style="margin-top: 20px;">
+      <div class="pk-phase">
+        <span class="ph">TRUTH</span>
+        <span class="pd"><span class="en-only">A question hangs over everything. In a world where records, prices, and promises can be quietly rewritten, what can an ordinary person actually verify?</span><span class="th-only">คำถามที่ลอยอยู่เหนือทุกสิ่ง — ในโลกที่บันทึก ราคา และคำสัญญาถูกแก้ไขอย่างเงียบ ๆ ได้ คนธรรมดาตรวจสอบอะไรได้จริงบ้าง</span></span>
+      </div>
+      <div class="pk-phase">
+        <span class="ph">PAST</span>
+        <span class="pd"><span class="en-only">The rules of money are changed overnight, and nobody asks permission. A generation works hard, believes in stability, and unknowingly passes down debt along with its love.</span><span class="th-only">กติกาของเงินถูกเปลี่ยนในชั่วข้ามคืนโดยไม่มีใครขออนุญาต คนรุ่นหนึ่งทำงานหนัก เชื่อในความมั่นคง และส่งต่อหนี้ไปพร้อมกับความรักโดยไม่รู้ตัว</span></span>
+      </div>
+      <div class="pk-phase">
+        <span class="ph">PRESENT</span>
+        <span class="pd"><span class="en-only">Inflation eats quietly. One member of the family begins to question the system everyone else still trusts — and learns that seeing the exit is not the same as convincing the people you love to walk through it.</span><span class="th-only">เงินเฟ้อกัดกินอย่างเงียบเชียบ สมาชิกคนหนึ่งของครอบครัวเริ่มตั้งคำถามกับระบบที่ทุกคนยังเชื่อ — และพบว่าการมองเห็นทางออก ไม่เหมือนกับการพาคนที่รักเดินออกไปด้วยกัน</span></span>
+      </div>
+      <div class="pk-phase">
+        <span class="ph">FUTURE</span>
+        <span class="pd"><span class="en-only">A world built on rules nobody can quietly rewrite. Not a perfect world — a verifiable one. What the family passes on this time is the question that survives every era: don't trust. Verify.</span><span class="th-only">โลกที่สร้างบนกติกาที่ไม่มีใครแอบแก้ได้ ไม่ใช่โลกที่สมบูรณ์แบบ — แต่เป็นโลกที่ตรวจสอบได้ สิ่งที่ครอบครัวส่งต่อในครั้งนี้คือคำถามที่อยู่รอดทุกยุค: อย่าเชื่อ — จงตรวจสอบ</span></span>
+      </div>
+    </div>
+    <p class="pk-text en-only" style="margin-top: 24px;">Based on true events. The protagonist remains anonymous by design — he could be anyone trapped in a system designed for them to lose.</p>
+    <p class="pk-text th-only" style="margin-top: 24px;">สร้างจากเรื่องจริง ตัวเอกไม่มีชื่อโดยตั้งใจ — เขาคือใครก็ได้ที่ติดอยู่ในระบบที่ออกแบบมาให้แพ้</p>
+    <p class="pk-note en-only">NOTE: THE FEATURE SCREENPLAY IS IN ACTIVE DEVELOPMENT. DETAILED STORY MATERIALS ARE AVAILABLE TO PRESS AND PARTNERS ON REQUEST.</p>
+    <p class="pk-note th-only">หมายเหตุ: บทภาพยนตร์ฉบับเต็มอยู่ระหว่างการพัฒนา — สื่อและพาร์ตเนอร์ขอเอกสารเพิ่มเติมได้ทางอีเมล</p>
+  </div>
+
+  <div class="pk-block reveal">
+    <div class="pk-label green">TEASER</div>
+    <div class="pk-video">
+      <iframe src="https://www.youtube.com/embed/JxJdUSh11_o?rel=0&modestbranding=1" title="SATOSHI — Official Teaser" allow="fullscreen; picture-in-picture" allowfullscreen loading="lazy"></iframe>
+    </div>
+    <a href="https://www.youtube.com/watch?v=JxJdUSh11_o" target="_blank" rel="noopener" class="pk-link">WATCH ON YOUTUBE ↗</a>
+  </div>
+
+  <div class="pk-block reveal">
+    <div class="pk-label">STILLS &amp; KEY ART</div>
+    <div class="pk-stills">
+      <div class="pk-still">
+        <img src="assets/posters/poster-01.jpg" alt="SATOSHI key art 01" onclick="openLightbox('assets/posters/poster-01.jpg')">
+        <a href="assets/posters/poster-01.jpg" download class="pk-still-dl">↓ DOWNLOAD 01</a>
+      </div>
+      <div class="pk-still">
+        <img src="assets/posters/poster-02.jpg" alt="SATOSHI key art 02" onclick="openLightbox('assets/posters/poster-02.jpg')">
+        <a href="assets/posters/poster-02.jpg" download class="pk-still-dl">↓ DOWNLOAD 02</a>
+      </div>
+      <div class="pk-still">
+        <img src="assets/posters/poster-03.jpg" alt="SATOSHI key art 03" onclick="openLightbox('assets/posters/poster-03.jpg')">
+        <a href="assets/posters/poster-03.jpg" download class="pk-still-dl">↓ DOWNLOAD 03</a>
+      </div>
+    </div>
+    <p class="pk-note en-only">POSTER KEY ART. PRODUCTION STILLS WILL BE ADDED AS THE FEATURE ENTERS PRODUCTION.</p>
+    <p class="pk-note th-only">ภาพ key art จากโปสเตอร์ — ภาพนิ่งจากกองถ่ายจะเพิ่มเมื่อฉบับเต็มเข้าสู่การถ่ายทำ</p>
+  </div>
+
+  <div class="pk-block reveal">
+    <div class="pk-label green">FESTIVAL</div>
+    <div class="pk-festival">
+      <span class="f1">★ OFFICIAL SELECTION — BITCOIN FILMFEST 2026, WARSAW</span>
+      <span class="f2"><span class="en-only">Screened in the <strong>"Changing minds with fiction"</strong> block — the festival's Friday 18:00 prime-time fiction slot, June 2026, Warsaw, Poland.</span><span class="th-only">ฉายในบล็อก <strong>"Changing minds with fiction"</strong> — ช่วงภาพยนตร์ fiction คืนวันศุกร์ 18:00 (prime-time) มิถุนายน 2026 กรุงวอร์ซอ โปแลนด์</span></span>
+      <a href="https://bitcoinfilmfest.com/bff26/" target="_blank" rel="noopener" class="pk-link">SOURCE: bitcoinfilmfest.com/bff26 ↗</a>
+    </div>
+  </div>
+
+  <div class="pk-block reveal">
+    <div class="pk-label">DOWNLOADS</div>
+    <ul class="pk-dl-list">
+      <li><a href="assets/laurel-bff26.svg" download>↓ FESTIVAL LAUREL — BFF'26 (SVG)</a><span class="sz">WHITE / FOR DARK BACKGROUNDS</span></li>
+      <li><a href="assets/posters/poster-01.jpg" download>↓ KEY ART 01 (JPG)</a></li>
+      <li><a href="assets/posters/poster-02.jpg" download>↓ KEY ART 02 (JPG)</a></li>
+      <li><a href="assets/posters/poster-03.jpg" download>↓ KEY ART 03 (JPG)</a></li>
+    </ul>
+  </div>
+
+  <div class="pk-block reveal">
+    <div class="pk-contact">
+      <div class="c1">PRESS &amp; PARTNER CONTACT</div>
+      <div class="c2"><a href="mailto:satoshi21film@gmail.com">satoshi21film@gmail.com</a></div>
+      <div class="c3"><span class="en-only">Interviews, screeners, and additional materials on request.</span><span class="th-only">สัมภาษณ์ ขอ screener และเอกสารเพิ่มเติมได้ทางอีเมล</span></div>
+    </div>
+  </div>
+
+  <div class="pk-footer-links reveal">
+    <a href="support.html">SUPPORT THE FEATURE →</a>
+    <a href="index.html">← <span class="th-only">กลับหน้าหลัก /</span> BACK HOME</a>
+  </div>
+
+</main>
+
+<footer>
+  <div class="footer-content">
+    <div class="footer-logo">SATOSHi</div>
+    <div class="footer-copy">© 2026 SATOSHI FILM — CONFIDENTIAL</div>
+    <div class="footer-links">
+      <a href="index.html" class="th-only">หน้าหลัก</a>
+      <a href="index.html" class="en-only">HOME</a>
+      <a href="support.html" class="th-only">สนับสนุนฉบับเต็ม</a>
+      <a href="support.html" class="en-only">SUPPORT</a>
+      <a href="https://github.com/sootisooti/satoshi.film" target="_blank" class="th-only">ร่วมพัฒนาเว็บไซต์</a>
+      <a href="https://github.com/sootisooti/satoshi.film" target="_blank" class="en-only">WEBSITE COLLAB</a>
+      <a href="#" onclick="toggleLang(); return false;"><span>EN / TH</span></a>
+    </div>
+  </div>
+</footer>
+
+<button class="back-to-top" id="backToTop" onclick="window.scrollTo({top:0,behavior:'smooth'})" aria-label="Back to top">↑</button>
+
+<script>
+// Custom Cursor
+const dot = document.getElementById('cursorDot');
+const ring = document.getElementById('cursorRing');
+let mouseX = 0, mouseY = 0, ringX = 0, ringY = 0;
+document.addEventListener('mousemove', (e) => {
+  mouseX = e.clientX; mouseY = e.clientY;
+  dot.style.left = mouseX - 4 + 'px';
+  dot.style.top = mouseY - 4 + 'px';
+});
+function animateRing() {
+  ringX += (mouseX - ringX) * 0.15;
+  ringY += (mouseY - ringY) * 0.15;
+  ring.style.left = ringX - 4 + 'px';
+  ring.style.top = ringY - 4 + 'px';
+  requestAnimationFrame(animateRing);
+}
+animateRing();
+document.querySelectorAll('a, button').forEach(el => {
+  el.addEventListener('mouseenter', () => ring.classList.add('hovering'));
+  el.addEventListener('mouseleave', () => ring.classList.remove('hovering'));
+});
+
+function toggleLang() {
+  const body = document.body;
+  if (body.classList.contains('lang-th')) {
+    body.classList.remove('lang-th'); body.classList.add('lang-en');
+  } else {
+    body.classList.remove('lang-en'); body.classList.add('lang-th');
+  }
+}
+
+// Lightbox
+function openLightbox(src) {
+  var img = document.getElementById('lightboxImg');
+  var overlay = document.getElementById('lightboxOverlay');
+  img.src = src;
+  overlay.classList.add('active');
+}
+function closeLightbox(e) {
+  if (e && e.target !== document.getElementById('lightboxOverlay') && e.target !== document.querySelector('.lightbox-close')) return;
+  document.getElementById('lightboxOverlay').classList.remove('active');
+  document.getElementById('lightboxImg').src = '';
+}
+
+// Escape key
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') {
+    document.getElementById('lightboxOverlay').classList.remove('active');
+    document.getElementById('lightboxImg').src = '';
+  }
+});
+
+// Mobile Nav
+function toggleMobileNav() {
+  var menu = document.getElementById('navMenu');
+  var btn = document.getElementById('navHamburger');
+  menu.classList.toggle('mobile-open');
+  btn.classList.toggle('open');
+}
+function closeMobileNav() {
+  var menu = document.getElementById('navMenu');
+  var btn = document.getElementById('navHamburger');
+  if (menu) menu.classList.remove('mobile-open');
+  if (btn) btn.classList.remove('open');
+}
+document.addEventListener('click', function(e) {
+  var nav = document.querySelector('nav');
+  var menu = document.getElementById('navMenu');
+  if (menu && menu.classList.contains('mobile-open') && nav && !nav.contains(e.target)) closeMobileNav();
+});
+
+// Back to Top
+(function() {
+  var backBtn = document.getElementById('backToTop');
+  window.addEventListener('scroll', function() {
+    var scrollTop = window.scrollY || document.documentElement.scrollTop;
+    if (backBtn) {
+      if (scrollTop > 400) backBtn.classList.add('visible');
+      else backBtn.classList.remove('visible');
+    }
+  }, { passive: true });
+})();
+
+// Scroll Reveal
+const reveals = document.querySelectorAll('.reveal');
+const revealObserver = new IntersectionObserver((entries) => {
+  entries.forEach(entry => { if (entry.isIntersecting) entry.target.classList.add('visible'); });
+}, { threshold: 0.1, rootMargin: '0px 0px -40px 0px' });
+reveals.forEach(el => revealObserver.observe(el));
+</script>
+
+</body>
+</html>

--- a/support.html
+++ b/support.html
@@ -9,12 +9,12 @@
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="SATOSHI.FILM">
 <meta property="og:title" content="SUPPORT — Fund the SATOSHI Feature">
-<meta property="og:description" content="A Thai family drama about debt, fiat money, and truth. Screened at Bitcoin FilmFest 2026, Warsaw — now raising for the full feature. Every sat is visible proof of work.">
+<meta property="og:description" content="A Thai family drama about debt, fiat money, and truth. Official teaser screened at Bitcoin FilmFest 2026, Warsaw — now raising for the full feature. Every sat is visible proof of work.">
 <meta property="og:url" content="https://sootisooti.github.io/satoshi.film/support.html">
 <meta property="og:image" content="https://sootisooti.github.io/satoshi.film/assets/posters/poster-01.jpg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="SUPPORT — Fund the SATOSHI Feature">
-<meta name="twitter:description" content="Screened at Bitcoin FilmFest 2026, Warsaw — now raising for the full feature.">
+<meta name="twitter:description" content="Official teaser screened at Bitcoin FilmFest 2026, Warsaw — now raising for the full feature.">
 <meta name="twitter:image" content="https://sootisooti.github.io/satoshi.film/assets/posters/poster-01.jpg">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -214,16 +214,16 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
 
   <div class="sp-status reveal">
     <span>OFFICIAL SELECTION — BFF'26 WARSAW</span>
-    <span>SCREENED JUNE 2026</span>
+    <span>TEASER SCREENED JUNE 2026</span>
     <span>NOW RAISING THE FEATURE</span>
   </div>
 
   <div class="sp-block reveal">
     <div class="sp-label">WHERE WE ARE</div>
-    <p class="sp-text en-only"><strong>SATOSHI</strong> is a Thai family drama about debt, money, and truth — told through one ordinary family across four generations. In June 2026 the film screened at <strong>Bitcoin FilmFest in Warsaw</strong>, in the festival's Friday prime-time fiction block, "Changing minds with fiction".</p>
-    <p class="sp-text en-only">Now we are raising the budget to make the full feature. The screenplay is in active development. We won't promise you the moon — we'd rather show you the work: <strong>a teaser you can watch, a festival audience that has already sat with this story, and every sat accounted for in the open.</strong></p>
-    <p class="sp-text th-only"><strong>SATOSHI</strong> คือภาพยนตร์ดราม่าครอบครัวไทยว่าด้วยหนี้ เงิน และความจริง — เล่าผ่านครอบครัวธรรมดาหนึ่งครอบครัวข้ามสี่รุ่น เดือนมิถุนายน 2026 หนังได้ฉายที่ <strong>Bitcoin FilmFest กรุงวอร์ซอ</strong> ในบล็อกภาพยนตร์ fiction ช่วง prime-time คืนวันศุกร์ "Changing minds with fiction"</p>
-    <p class="sp-text th-only">ตอนนี้เรากำลังระดมทุนเพื่อสร้างฉบับเต็ม บทภาพยนตร์อยู่ระหว่างการพัฒนา เราไม่ขายฝัน — แต่อยากให้ดูจากผลงาน: <strong>teaser ที่ดูได้จริง ผู้ชมเทศกาลที่นั่งดูเรื่องนี้มาแล้ว และทุก sat ที่เข้ามาตรวจสอบได้อย่างเปิดเผย</strong></p>
+    <p class="sp-text en-only"><strong>SATOSHI</strong> is a Thai family drama about debt, money, and truth — told through one ordinary family across four generations. In June 2026 its <strong>official teaser</strong> screened at <strong>Bitcoin FilmFest in Warsaw</strong>, selected into the festival's Friday prime-time fiction block, "Changing minds with fiction". The teaser alone earned that slot. The feature is what we're here to make.</p>
+    <p class="sp-text en-only">Now we are raising the budget to make the full feature. The screenplay is in active development. We won't promise you the moon — we'd rather show you the work: <strong>a teaser you can watch, a festival audience that has already sat with it, and every sat accounted for in the open.</strong></p>
+    <p class="sp-text th-only"><strong>SATOSHI</strong> คือภาพยนตร์ดราม่าครอบครัวไทยว่าด้วยหนี้ เงิน และความจริง — เล่าผ่านครอบครัวธรรมดาหนึ่งครอบครัวข้ามสี่รุ่น เดือนมิถุนายน 2026 <strong>teaser อย่างเป็นทางการ</strong>ของหนังได้รับคัดเลือกและฉายที่ <strong>Bitcoin FilmFest กรุงวอร์ซอ</strong> ในบล็อกภาพยนตร์ fiction ช่วง prime-time คืนวันศุกร์ "Changing minds with fiction" — แค่ teaser ก็ได้ slot นั้นมาแล้ว ฉบับเต็มคือสิ่งที่เรากำลังจะสร้าง</p>
+    <p class="sp-text th-only">ตอนนี้เรากำลังระดมทุนเพื่อสร้างฉบับเต็ม บทภาพยนตร์อยู่ระหว่างการพัฒนา เราไม่ขายฝัน — แต่อยากให้ดูจากผลงาน: <strong>teaser ที่ดูได้จริง ผู้ชมเทศกาลที่นั่งดูมันมาแล้ว และทุก sat ที่เข้ามาตรวจสอบได้อย่างเปิดเผย</strong></p>
   </div>
 
   <div class="sp-block reveal">

--- a/support.html
+++ b/support.html
@@ -1,10 +1,21 @@
 <!DOCTYPE html>
-<html lang="th">
+<html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>SATOSHI — POSTER</title>
-<meta name="description" content="โปสเตอร์ภาพยนตร์ SATOSHI — คนหนึ่งคน กับคอมหนึ่งเครื่อง · Official Selection — Bitcoin FilmFest 2026, Warsaw">
+<title>SUPPORT — Fund the SATOSHI Feature | SATOSHI.FILM</title>
+<meta name="description" content="Help make the full SATOSHI feature — a Thai family drama about debt, fiat money, and truth across four generations. Official Selection — Bitcoin FilmFest 2026, Warsaw. Zap via Lightning or contact us for investment.">
+<link rel="canonical" href="https://sootisooti.github.io/satoshi.film/support.html">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="SATOSHI.FILM">
+<meta property="og:title" content="SUPPORT — Fund the SATOSHI Feature">
+<meta property="og:description" content="A Thai family drama about debt, fiat money, and truth. Screened at Bitcoin FilmFest 2026, Warsaw — now raising for the full feature. Every sat is visible proof of work.">
+<meta property="og:url" content="https://sootisooti.github.io/satoshi.film/support.html">
+<meta property="og:image" content="https://sootisooti.github.io/satoshi.film/assets/posters/poster-01.jpg">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="SUPPORT — Fund the SATOSHI Feature">
+<meta name="twitter:description" content="Screened at Bitcoin FilmFest 2026, Warsaw — now raising for the full feature.">
+<meta name="twitter:image" content="https://sootisooti.github.io/satoshi.film/assets/posters/poster-01.jpg">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Space+Mono:ital,wght@0,400;0,700;1,400&family=Noto+Serif+Thai:wght@400;700&family=Sarabun:wght@300;400;600;700&display=swap" rel="stylesheet">
@@ -31,17 +42,9 @@ nav { position: fixed; top: 0; left: 0; right: 0; z-index: 1000; display: grid; 
 .nav-right { display: flex; align-items: center; gap: 12px; flex-shrink: 0; }
 .lang-toggle { font-family: 'Space Mono', monospace; font-size: 12px; letter-spacing: 2px; color: #666660; border: 1px solid #666660; padding: 6px 14px; background: transparent; cursor: none; transition: all 0.3s; }
 .lang-toggle:hover { color: #F7931A; border-color: #F7931A; }
-
-/* Nav Action Buttons */
 .nav-action-btn { font-family: 'Space Mono', monospace; font-size: 0.7rem; text-decoration: none; letter-spacing: 0.15em; padding: 6px 14px; transition: background 0.2s, box-shadow 0.2s; display: inline-block; }
 .nav-zap-btn { color: #F7931A; border: 1px solid rgba(247,147,26,0.5); }
 .nav-zap-btn:hover { background: rgba(247,147,26,0.12); box-shadow: 0 0 10px rgba(247,147,26,0.25); }
-.nav-seed-link { color: #00FF41; border: 1px solid rgba(0,255,65,0.3); }
-.nav-seed-link:hover { background: rgba(0,255,65,0.08); }
-.nav-forum-link { color: #00FF41; border: 1px solid rgba(0,255,65,0.3); }
-.nav-forum-link:hover { background: rgba(0,255,65,0.08); }
-.nav-dialogue-link { color: #F7931A; border: 1px solid rgba(247,147,26,0.3); }
-.nav-dialogue-link:hover { background: rgba(247,147,26,0.08); }
 
 /* Auth / Zap Modal */
 .auth-overlay { position: fixed; inset: 0; background: rgba(8,8,6,0.95); z-index: 10002; display: none; align-items: center; justify-content: center; backdrop-filter: blur(12px); }
@@ -57,35 +60,51 @@ nav { position: fixed; top: 0; left: 0; right: 0; z-index: 1000; display: grid; 
 .auth-close { position: absolute; top: 16px; right: 20px; font-size: 22px; color: #666660; background: none; border: none; cursor: none; transition: color 0.2s; z-index: 10; }
 .auth-close:hover { color: #F7931A; }
 
-/* Poster Section */
-.poster-page { padding: 140px 40px 120px; background: #080806; min-height: 100vh; }
-.poster-eyebrow { font-family: 'Space Mono', monospace; font-size: 9px; letter-spacing: 3px; color: #666660; margin-bottom: 12px; text-align: center; }
-.poster-title-th { font-family: 'Noto Serif Thai', serif; font-size: 16px; color: #666660; text-align: center; margin-bottom: 8px; opacity: 0.7; }
-.poster-title-en { font-family: 'Space Mono', monospace; font-size: 64px; font-weight: 700; color: #d4d0c8; text-align: center; letter-spacing: 4px; opacity: 0.15; line-height: 1; margin-bottom: 60px; }
-
-.poster-main-wrap { display: flex; flex-direction: column; align-items: center; margin: 0 auto; max-width: 420px; }
-.poster-main-img { width: 100%; max-width: 420px; display: block; border: 1px solid rgba(255,255,255,0.04); filter: brightness(0.92); cursor: pointer; transition: filter 0.3s, border-color 0.3s; }
-.poster-main-img:hover { filter: brightness(1); border-color: rgba(255,255,255,0.1); }
-
-.poster-caption { max-width: 420px; width: 100%; border-top: 1px solid rgba(255,255,255,0.06); padding-top: 16px; margin-top: 0; }
-.poster-caption-title { font-family: 'Space Mono', monospace; font-size: 13px; letter-spacing: 2px; color: #d4d0c8; margin-bottom: 6px; }
-.poster-caption-subtitle { font-family: 'Sarabun', sans-serif; font-size: 14px; color: #666660; margin-bottom: 10px; line-height: 1.6; }
-.poster-caption-meta { font-family: 'Space Mono', monospace; font-size: 9px; letter-spacing: 2px; color: #666660; }
-.poster-caption-meta .meta-year { color: #F7931A; }
-
-.poster-alt-row { display: flex; flex-direction: row; gap: 2px; max-width: 420px; width: 100%; margin: 40px auto 0; }
-.poster-alt-img { flex: 1; min-width: 0; display: block; width: 100%; opacity: 0.4; cursor: pointer; border: 1px solid rgba(255,255,255,0.02); transition: opacity 0.3s, border-color 0.3s; }
-.poster-alt-img:hover { opacity: 0.8; border-color: rgba(255,255,255,0.08); }
-
-.poster-back { display: block; text-align: center; margin: 60px auto 0; font-family: 'Space Mono', monospace; font-size: 10px; letter-spacing: 2px; color: #666660; text-decoration: none; transition: color 0.3s; }
-.poster-back:hover { color: #F7931A; }
-
-/* Lightbox */
-.lightbox-overlay { position: fixed; inset: 0; background: rgba(8,8,6,0.97); z-index: 20000; display: none; align-items: center; justify-content: center; cursor: pointer; }
-.lightbox-overlay.active { display: flex; }
-.lightbox-img { max-width: 90vw; max-height: 90vh; object-fit: contain; display: block; cursor: default; }
-.lightbox-close { position: fixed; top: 24px; right: 28px; font-size: 28px; color: #666660; background: none; border: none; cursor: pointer; transition: color 0.2s; font-family: 'Space Mono', monospace; z-index: 20001; line-height: 1; }
-.lightbox-close:hover { color: #F7931A; }
+/* Support Page */
+.sp-page { padding: 150px 40px 100px; max-width: 880px; margin: 0 auto; }
+.sp-eyebrow { font-family: 'Space Mono', monospace; font-size: 10px; letter-spacing: 4px; color: #666660; margin-bottom: 16px; text-align: center; }
+.sp-title { font-family: 'Space Mono', monospace; font-size: clamp(28px, 6vw, 56px); font-weight: 700; letter-spacing: 0.06em; color: #d4d0c8; text-align: center; line-height: 1.15; }
+.sp-title span { color: #F7931A; }
+.sp-title-th { font-family: 'Noto Serif Thai', serif; font-size: clamp(16px, 3vw, 24px); color: #F7931A; opacity: 0.7; text-align: center; margin-top: 12px; letter-spacing: 0.15em; }
+.sp-status { display: flex; justify-content: center; flex-wrap: wrap; gap: 0; margin: 36px auto 0; }
+.sp-status span { font-family: 'Space Mono', monospace; font-size: 10px; letter-spacing: 2px; color: #d4d0c8; opacity: 0.6; padding: 8px 16px; border-left: 2px solid #00FF41; }
+.sp-block { margin-top: 72px; }
+.sp-label { font-family: 'Space Mono', monospace; font-size: 10px; letter-spacing: 5px; color: #F7931A; margin-bottom: 20px; }
+.sp-label.green { color: #00FF41; }
+.sp-text { font-family: 'Sarabun', sans-serif; font-size: 16px; line-height: 1.9; color: #8a877e; max-width: 680px; }
+.sp-text strong { color: #d4d0c8; font-weight: 600; }
+.sp-text + .sp-text { margin-top: 16px; }
+.sp-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 2px; margin-top: 24px; }
+.sp-card { background: #0e0e0b; padding: 40px 32px; border-top: 2px solid transparent; transition: all 0.5s; position: relative; }
+.sp-card:hover { background: #121210; }
+.sp-card.btc { border-top-color: rgba(247,147,26,0.5); }
+.sp-card.inv { border-top-color: rgba(139,168,196,0.5); }
+.sp-card-title { font-family: 'Space Mono', monospace; font-size: 13px; letter-spacing: 3px; color: #d4d0c8; margin-bottom: 6px; }
+.sp-card-sub { font-family: 'Sarabun', sans-serif; font-size: 13px; color: #666660; margin-bottom: 24px; }
+.sp-card-desc { font-family: 'Sarabun', sans-serif; font-size: 14px; line-height: 1.8; color: #8a877e; margin-bottom: 24px; }
+.sp-addr { background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.1); padding: 14px 16px; display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 10px; margin-bottom: 12px; }
+.sp-addr code { font-family: 'Space Mono', monospace; color: #00FF41; font-size: 12px; word-break: break-all; }
+.sp-copy-btn { background: #F7931A; color: #080806; border: none; font-family: 'Space Mono', monospace; font-size: 10px; padding: 8px 16px; cursor: none; transition: all 0.3s; }
+.sp-copy-btn:hover { background: #d4d0c8; }
+.sp-copied { font-family: 'Space Mono', monospace; font-size: 10px; color: #00FF41; margin-bottom: 12px; display: none; }
+.sp-cta { font-family: 'Space Mono', monospace; font-size: 11px; letter-spacing: 2px; padding: 13px 26px; text-decoration: none; display: inline-block; transition: all 0.3s; background: transparent; cursor: none; border: 1px solid rgba(247,147,26,0.4); color: #F7931A; }
+.sp-cta:hover { background: rgba(247,147,26,0.08); border-color: #F7931A; }
+.sp-cta.blue { border-color: rgba(139,168,196,0.4); color: #8BA8C4; }
+.sp-cta.blue:hover { background: rgba(139,168,196,0.08); border-color: #8BA8C4; }
+.sp-tier-list { list-style: none; margin: 0 0 24px; }
+.sp-tier-list li { display: flex; justify-content: space-between; gap: 12px; padding: 10px 0; border-bottom: 1px solid rgba(255,255,255,0.05); font-size: 13px; }
+.sp-tier-list .amt { font-family: 'Space Mono', monospace; color: #F7931A; white-space: nowrap; }
+.sp-tier-list .what { font-family: 'Sarabun', sans-serif; color: #8a877e; text-align: right; }
+.sp-list { list-style: none; margin-top: 24px; }
+.sp-list li { display: flex; gap: 18px; padding: 18px 0; border-bottom: 1px solid rgba(255,255,255,0.05); align-items: baseline; }
+.sp-list .k { font-family: 'Space Mono', monospace; font-size: 11px; letter-spacing: 2px; color: #00FF41; white-space: nowrap; min-width: 130px; }
+.sp-list .v { font-family: 'Sarabun', sans-serif; font-size: 14px; line-height: 1.7; color: #8a877e; }
+.sp-note { border-left: 2px solid #F7931A; padding: 20px 24px; background: rgba(247,147,26,0.03); margin-top: 72px; }
+.sp-note p { font-family: 'Sarabun', sans-serif; font-size: 15px; line-height: 1.9; color: #8a877e; }
+.sp-note p strong { color: #d4d0c8; }
+.sp-footer-links { margin-top: 72px; display: flex; justify-content: center; gap: 28px; flex-wrap: wrap; }
+.sp-footer-links a { font-family: 'Space Mono', monospace; font-size: 10px; letter-spacing: 2px; color: #666660; text-decoration: none; transition: color 0.3s; }
+.sp-footer-links a:hover { color: #F7931A; }
 
 /* Footer */
 footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); }
@@ -100,11 +119,14 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
 .reveal { opacity: 0; transform: translateY(30px); transition: opacity 0.8s, transform 0.8s; }
 .reveal.visible { opacity: 1; transform: translateY(0); }
 
+/* Back to Top */
+.back-to-top { position: fixed; bottom: 32px; right: 32px; width: 44px; height: 44px; background: rgba(8,8,6,0.85); border: 1px solid rgba(247,147,26,0.3); color: #F7931A; font-family: 'Space Mono', monospace; font-size: 16px; cursor: none; opacity: 0; pointer-events: none; transition: opacity 0.3s, border-color 0.3s, background 0.3s; z-index: 499; display: flex; align-items: center; justify-content: center; line-height: 1; }
+.back-to-top.visible { opacity: 1; pointer-events: all; }
+.back-to-top:hover { border-color: #F7931A; background: rgba(247,147,26,0.1); }
+
 /* Mobile Nav */
 @media (max-width: 1200px) { nav { padding: 18px 24px; gap: 12px; } .nav-menu { gap: 14px; } .nav-link { font-size: 9px; letter-spacing: 0.5px; } }
 @media (max-width: 900px) { nav { grid-template-columns: auto 1fr; padding: 16px 20px; gap: 12px; } .nav-menu { gap: 12px 8px; justify-content: flex-start; } .nav-right { grid-column: 1 / -1; justify-content: flex-end; margin-top: 4px; } }
-
-/* Nav Hamburger */
 .nav-hamburger { display: none; flex-direction: column; justify-content: center; gap: 5px; width: 44px; height: 44px; background: transparent; border: none; cursor: none; padding: 0 10px; flex-shrink: 0; }
 .nav-hamburger span { display: block; width: 20px; height: 1.5px; background: #d4d0c8; transition: all 0.3s; }
 .nav-hamburger.open span:nth-child(1) { transform: translateY(6.5px) rotate(45deg); }
@@ -113,27 +135,8 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
 .mobile-only { display: none !important; }
 .nav-mobile-divider { width: 100%; height: 1px; background: rgba(247,147,26,0.15); margin: 8px 0; }
 
-/* Back to Top */
-.back-to-top { position: fixed; bottom: 32px; right: 32px; width: 44px; height: 44px; background: rgba(8,8,6,0.85); border: 1px solid rgba(247,147,26,0.3); color: #F7931A; font-family: 'Space Mono', monospace; font-size: 16px; cursor: none; opacity: 0; pointer-events: none; transition: opacity 0.3s, border-color 0.3s, background 0.3s; z-index: 499; display: flex; align-items: center; justify-content: center; line-height: 1; }
-.back-to-top.visible { opacity: 1; pointer-events: all; }
-.back-to-top:hover { border-color: #F7931A; background: rgba(247,147,26,0.1); }
-
-/* Zap Float */
-.zap-float { position: fixed; bottom: 32px; left: 32px; width: 44px; height: 44px; background: rgba(8,8,6,0.85); border: 1px solid rgba(247,147,26,0.5); color: #F7931A; font-family: 'Space Mono', monospace; font-size: 18px; cursor: none; opacity: 1; pointer-events: all; transition: border-color 0.3s, background 0.3s, box-shadow 0.3s; z-index: 499; display: flex; align-items: center; justify-content: center; line-height: 1; }
-.zap-float:hover { border-color: #F7931A; background: rgba(247,147,26,0.15); box-shadow: 0 0 14px rgba(247,147,26,0.35); }
-
-/* Pre-production Banner */
-.preprod-banner { position: fixed; top: 0; left: 0; right: 0; z-index: 9999; background: rgba(247,147,26,0.95); color: #080806; padding: 10px 16px; display: flex; justify-content: center; align-items: center; box-shadow: 0 2px 8px rgba(0,0,0,0.3); border-bottom: 1px solid rgba(8,8,6,0.1); transition: transform 0.3s ease-out, opacity 0.3s ease-out; }
-.preprod-banner.dismissed { transform: translateY(-100%); opacity: 0; }
-.preprod-content { display: flex; align-items: center; justify-content: space-between; width: 100%; max-width: 1200px; gap: 16px; }
-.preprod-text { font-family: 'Space Mono', monospace; font-size: 12px; line-height: 1.6; display: flex; flex-direction: column; gap: 2px; }
-.preprod-text span:first-child { font-family: 'Sarabun', sans-serif; }
-.preprod-close { background: transparent; border: none; color: #080806; font-size: 28px; line-height: 1; cursor: none; padding: 0; width: 44px; height: 44px; display: flex; align-items: center; justify-content: center; flex-shrink: 0; transition: opacity 0.2s; font-family: 'Space Mono', monospace; }
-.preprod-close:hover { opacity: 0.7; }
-
 @media (max-width: 640px) {
   .nav-hamburger { display: flex; }
-  .nav-seed-link, .nav-forum-link, .nav-dialogue-link { display: none; }
   .mobile-only { display: block !important; }
   nav { grid-template-columns: auto 1fr auto; }
   .nav-right { grid-column: auto; margin-top: 0; gap: 4px; }
@@ -142,26 +145,16 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
   .nav-link { font-size: 12px; letter-spacing: 1px; padding: 14px 0; border-bottom: 1px solid rgba(255,255,255,0.05); color: #d4d0c8; width: 100%; }
   .nav-link:last-of-type { border-bottom: none; }
   .back-to-top { bottom: 20px; right: 16px; width: 40px; height: 40px; font-size: 14px; }
-  .zap-float { bottom: 20px; left: 16px; width: 40px; height: 40px; font-size: 16px; }
-  .preprod-text { font-size: 11px; }
-  .preprod-banner { padding: 8px 12px; }
-  .poster-page { padding: 120px 20px 80px; }
-  .poster-title-en { font-size: 36px; }
-  .poster-alt-row { gap: 2px; }
+  .sp-page { padding: 130px 20px 80px; }
+  .sp-grid { grid-template-columns: 1fr; }
+  .sp-card { padding: 32px 24px; }
+  .sp-status span { font-size: 9px; padding: 6px 12px; }
+  .sp-list .k { min-width: 100px; }
+  .sp-list li { flex-direction: column; gap: 6px; }
 }
 </style>
 </head>
-<body class="lang-th">
-
-<div id="preProdBanner" class="preprod-banner">
-  <div class="preprod-content">
-    <span class="preprod-text">
-      <span>ฉายแล้วที่ Bitcoin FilmFest 2026 วอร์ซอ — กำลังระดมทุนสร้างฉบับเต็ม · ขออภัยหาก feature บางส่วนยังไม่ทำงาน</span>
-      <span>Screened at Bitcoin FilmFest 2026, Warsaw — now raising the full feature · Apologies if some features don't work yet</span>
-    </span>
-    <button class="preprod-close" onclick="dismissPreProdBanner()" aria-label="Close banner">×</button>
-  </div>
-</div>
+<body class="lang-en">
 
 <div class="cursor-dot" id="cursorDot"></div>
 <div class="cursor-ring" id="cursorRing"></div>
@@ -195,82 +188,107 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
   </div>
 </div>
 
-<!-- Lightbox -->
-<div class="lightbox-overlay" id="lightboxOverlay" onclick="closeLightbox(event)">
-  <button class="lightbox-close" onclick="closeLightbox(null)" aria-label="Close lightbox">×</button>
-  <img class="lightbox-img" id="lightboxImg" src="" alt="SATOSHI poster" onclick="event.stopPropagation()">
-</div>
-
 <nav>
-  <a href="index.html" class="nav-logo">SATOSHi <span class="nav-page-label">POSTER</span></a>
+  <a href="index.html" class="nav-logo">SATOSHi <span class="nav-page-label">SUPPORT</span></a>
   <div class="nav-menu" id="navMenu">
     <a href="index.html" class="nav-link"><span class="th-only">หน้าหลัก</span><span class="en-only">HOME</span></a>
-    <a href="support.html" class="nav-link"><span class="th-only">สนับสนุนฉบับเต็ม</span><span class="en-only">SUPPORT</span></a>
     <a href="press.html" class="nav-link"><span class="th-only">ข้อมูลสื่อ — PRESS</span><span class="en-only">PRESS KIT</span></a>
-    <a href="https://app.gitbook.com/invite/CC1p6uOmzX05YyLDPevJ/r3fCPzAmLSaX2XHCIdgr" target="_blank" class="nav-link th-only">ร่วมพัฒนาบทภาพยนตร์และสารคดี</a>
-    <a href="https://app.gitbook.com/invite/CC1p6uOmzX05YyLDPevJ/r3fCPzAmLSaX2XHCIdgr" target="_blank" class="nav-link en-only">SCRIPT &amp; DOC COLLAB</a>
+    <a href="photobook.html" class="nav-link"><span class="th-only">หนัง / สื่อ / ภาพ</span><span class="en-only">SATOSHI.MEDIA</span></a>
     <a href="https://github.com/sootisooti/satoshi.film" target="_blank" class="nav-link th-only">ร่วมพัฒนาเว็ปไซต์ SATOSHi</a>
     <a href="https://github.com/sootisooti/satoshi.film" target="_blank" class="nav-link en-only">WEBSITE COLLAB</a>
     <div class="nav-mobile-divider mobile-only"></div>
     <a href="#" class="nav-link mobile-only" onclick="closeMobileNav();openZapModal();" style="color:#F7931A;"><span class="th-only">⚡ สนับสนุนหนัง</span><span class="en-only">⚡ SUPPORT / ZAP</span></a>
-    <a href="verifier.html" class="nav-link mobile-only" onclick="closeMobileNav()"><span class="th-only">ตรวจสอบ</span><span class="en-only">SEED / VERIFY</span></a>
-    <a href="forum.html" class="nav-link mobile-only" onclick="closeMobileNav()"><span class="th-only">ชุมชน</span><span class="en-only">FORUM</span></a>
-    <a href="dialogue.html" class="nav-link mobile-only" onclick="closeMobileNav()"><span class="th-only">บทภาพยนตร์</span><span class="en-only">DIALOGUE</span></a>
   </div>
   <div class="nav-right">
     <a href="#" onclick="event.preventDefault();openZapModal();" class="nav-action-btn nav-zap-btn"><span class="th-only">⚡ สนับสนุน</span><span class="en-only">⚡ ZAP</span></a>
-    <a href="verifier.html" class="nav-action-btn nav-seed-link"><span class="th-only">SEED</span><span class="en-only">SEED</span></a>
-    <a href="forum.html" class="nav-action-btn nav-forum-link"><span class="th-only">ชุมชน</span><span class="en-only">FORUM</span></a>
-    <a href="dialogue.html" class="nav-action-btn nav-dialogue-link"><span class="th-only">บทภาพยนตร์</span><span class="en-only">DIALOGUE</span></a>
     <button class="lang-toggle" onclick="toggleLang()"><span>EN / TH</span></button>
     <button class="nav-hamburger" id="navHamburger" aria-label="Toggle navigation" onclick="toggleMobileNav()"><span></span><span></span><span></span></button>
   </div>
 </nav>
 
-<section class="poster-page">
-  <div class="poster-eyebrow reveal">OFFICIAL SELECTION — BFF'26 · <span class="block-num" id="posterBlockHeight">---</span> · 2026</div>
-  <div class="poster-title-th reveal th-only">โปสเตอร์</div>
-  <div class="poster-title-en reveal">POSTER</div>
+<main class="sp-page">
 
-  <div class="poster-main-wrap reveal">
-    <img
-      class="poster-main-img"
-      src="assets/posters/poster-01.jpg"
-      alt="SATOSHI — ซาโตชิ · Official poster"
-      onclick="openLightbox('assets/posters/poster-01.jpg')"
-    >
-    <div class="poster-caption">
-      <div class="poster-caption-title">SATOSHI — ซาโตชิ</div>
-      <div class="poster-caption-subtitle th-only">คนหนึ่งคน กับคอมหนึ่งเครื่อง</div>
-      <div class="poster-caption-meta"><span class="meta-year">2026</span> · FEATURE FILM · OFFICIAL SELECTION — BITCOIN FILMFEST 2026</div>
+  <div class="sp-eyebrow reveal">SUPPORT — สนับสนุน</div>
+  <h1 class="sp-title reveal">FUND THE <span>FEATURE</span></h1>
+  <div class="sp-title-th reveal">ร่วมสร้างภาพยนตร์ฉบับเต็ม</div>
+
+  <div class="sp-status reveal">
+    <span>OFFICIAL SELECTION — BFF'26 WARSAW</span>
+    <span>SCREENED JUNE 2026</span>
+    <span>NOW RAISING THE FEATURE</span>
+  </div>
+
+  <div class="sp-block reveal">
+    <div class="sp-label">WHERE WE ARE</div>
+    <p class="sp-text en-only"><strong>SATOSHI</strong> is a Thai family drama about debt, money, and truth — told through one ordinary family across four generations. In June 2026 the film screened at <strong>Bitcoin FilmFest in Warsaw</strong>, in the festival's Friday prime-time fiction block, "Changing minds with fiction".</p>
+    <p class="sp-text en-only">Now we are raising the budget to make the full feature. The screenplay is in active development. We won't promise you the moon — we'd rather show you the work: <strong>a teaser you can watch, a festival audience that has already sat with this story, and every sat accounted for in the open.</strong></p>
+    <p class="sp-text th-only"><strong>SATOSHI</strong> คือภาพยนตร์ดราม่าครอบครัวไทยว่าด้วยหนี้ เงิน และความจริง — เล่าผ่านครอบครัวธรรมดาหนึ่งครอบครัวข้ามสี่รุ่น เดือนมิถุนายน 2026 หนังได้ฉายที่ <strong>Bitcoin FilmFest กรุงวอร์ซอ</strong> ในบล็อกภาพยนตร์ fiction ช่วง prime-time คืนวันศุกร์ "Changing minds with fiction"</p>
+    <p class="sp-text th-only">ตอนนี้เรากำลังระดมทุนเพื่อสร้างฉบับเต็ม บทภาพยนตร์อยู่ระหว่างการพัฒนา เราไม่ขายฝัน — แต่อยากให้ดูจากผลงาน: <strong>teaser ที่ดูได้จริง ผู้ชมเทศกาลที่นั่งดูเรื่องนี้มาแล้ว และทุก sat ที่เข้ามาตรวจสอบได้อย่างเปิดเผย</strong></p>
+  </div>
+
+  <div class="sp-block reveal">
+    <div class="sp-label green">TWO WAYS IN</div>
+    <div class="sp-grid">
+
+      <div class="sp-card btc">
+        <div class="sp-card-title">⚡ FOR BITCOINERS</div>
+        <div class="sp-card-sub"><span class="en-only">Zap any amount. Every sat is visible proof of work.</span><span class="th-only">Zap เท่าไหร่ก็ได้ — ทุก sat คือ proof of work ที่มองเห็นได้</span></div>
+        <div class="sp-addr">
+          <code id="spAddressTxt">satoshifilm@walletofsatoshi.com</code>
+          <button class="sp-copy-btn" onclick="copySupportAddr()">COPY</button>
+        </div>
+        <div class="sp-copied" id="spCopied">✓ COPIED TO CLIPBOARD</div>
+        <ul class="sp-tier-list">
+          <li><span class="amt">2,100 SATS — SEED</span><span class="what"><span class="en-only">Script development</span><span class="th-only">สนับสนุนการพัฒนาบท</span></span></li>
+          <li><span class="amt">21,000 SATS — NODE</span><span class="what"><span class="en-only">Name in credits + community</span><span class="th-only">ชื่อใน credits + community</span></span></li>
+          <li><span class="amt">210,000 SATS — BLOCK</span><span class="what"><span class="en-only">Co-producer credit + private screening</span><span class="th-only">Co-producer credit + รอบฉายส่วนตัว</span></span></li>
+        </ul>
+        <a href="lightning:satoshifilm@walletofsatoshi.com" class="sp-cta">⚡ OPEN WALLET</a>
+      </div>
+
+      <div class="sp-card inv">
+        <div class="sp-card-title">FOR INVESTORS &amp; SPONSORS</div>
+        <div class="sp-card-sub"><span class="en-only">Film financiers, brands, and co-producers.</span><span class="th-only">ผู้ลงทุนภาพยนตร์ แบรนด์ และผู้ร่วมอำนวยการสร้าง</span></div>
+        <p class="sp-card-desc en-only">If you finance films — or want your name attached to one about money that tells the truth — write to us. Available on request: project deck, budget &amp; finance plan, screenplay status, and festival materials. Plain answers about timeline and risk, no hype.</p>
+        <p class="sp-card-desc th-only">ถ้าคุณลงทุนในภาพยนตร์ — หรืออยากให้ชื่อของคุณอยู่กับหนังที่พูดความจริงเรื่องเงิน — เขียนหาเรา ขอดูได้: project deck งบประมาณและแผนการเงิน สถานะบทภาพยนตร์ และเอกสารเทศกาล เราตอบตรงไปตรงมาเรื่อง timeline และความเสี่ยง ไม่ขายฝัน</p>
+        <div class="sp-addr">
+          <code>satoshi21film@gmail.com</code>
+        </div>
+        <a href="mailto:satoshi21film@gmail.com?subject=SATOSHI%20—%20Investor%20%2F%20Sponsor%20Inquiry" class="sp-cta blue">WRITE TO US →</a>
+      </div>
+
     </div>
   </div>
 
-  <div class="poster-alt-row reveal">
-    <img
-      class="poster-alt-img"
-      src="assets/posters/poster-02.jpg"
-      alt="SATOSHI poster 02"
-      onclick="openLightbox('assets/posters/poster-02.jpg')"
-    >
-    <img
-      class="poster-alt-img"
-      src="assets/posters/poster-03.jpg"
-      alt="SATOSHI poster 03"
-      onclick="openLightbox('assets/posters/poster-03.jpg')"
-    >
+  <div class="sp-block reveal">
+    <div class="sp-label">WHAT THE FUNDS BUILD</div>
+    <ul class="sp-list">
+      <li><span class="k">DEVELOPMENT</span><span class="v"><span class="en-only">Screenplay (in active rewrite), casting, and locations across Thailand.</span><span class="th-only">บทภาพยนตร์ (อยู่ระหว่าง rewrite) การคัดเลือกนักแสดง และโลเคชันทั่วประเทศไทย</span></span></li>
+      <li><span class="k">PRODUCTION</span><span class="v"><span class="en-only">Principal photography — a story spanning four generations of one family.</span><span class="th-only">การถ่ายทำหลัก — เรื่องราวข้ามสี่รุ่นของครอบครัวเดียว</span></span></li>
+      <li><span class="k">POST &amp; FESTIVALS</span><span class="v"><span class="en-only">Edit, sound, color, subtitles, and the festival run that follows.</span><span class="th-only">ตัดต่อ เสียง สี ซับไตเติล และการเดินทางสู่เทศกาลภาพยนตร์</span></span></li>
+    </ul>
   </div>
 
-  <a href="index.html" class="poster-back reveal">← <span class="th-only">กลับหน้าหลัก /</span> BACK HOME</a>
-</section>
+  <div class="sp-note reveal">
+    <p class="en-only">An independent film is a long game of proof of work. <strong>We can't promise returns. We can promise that every block of this film gets built — and verified — in the open.</strong></p>
+    <p class="th-only">หนังอิสระคือเกมยาวของ proof of work <strong>เราสัญญาผลตอบแทนไม่ได้ แต่สัญญาได้ว่าทุกบล็อกของหนังเรื่องนี้จะถูกสร้าง — และตรวจสอบได้ — อย่างเปิดเผย</strong></p>
+  </div>
+
+  <div class="sp-footer-links reveal">
+    <a href="press.html">PRESS KIT →</a>
+    <a href="index.html">← <span class="th-only">กลับหน้าหลัก /</span> BACK HOME</a>
+  </div>
+
+</main>
 
 <footer>
   <div class="footer-content">
     <div class="footer-logo">SATOSHi</div>
     <div class="footer-copy">© 2026 SATOSHI FILM — CONFIDENTIAL</div>
     <div class="footer-links">
-      <a href="https://app.gitbook.com/invite/CC1p6uOmzX05YyLDPevJ/r3fCPzAmLSaX2XHCIdgr" target="_blank" class="th-only">ร่วมพัฒนาบทภาพยนตร์</a>
-      <a href="https://app.gitbook.com/invite/CC1p6uOmzX05YyLDPevJ/r3fCPzAmLSaX2XHCIdgr" target="_blank" class="en-only">SCRIPT &amp; DOC COLLAB</a>
+      <a href="index.html" class="th-only">หน้าหลัก</a>
+      <a href="index.html" class="en-only">HOME</a>
+      <a href="press.html">PRESS KIT</a>
       <a href="https://github.com/sootisooti/satoshi.film" target="_blank" class="th-only">ร่วมพัฒนาเว็บไซต์</a>
       <a href="https://github.com/sootisooti/satoshi.film" target="_blank" class="en-only">WEBSITE COLLAB</a>
       <a href="#" onclick="toggleLang(); return false;"><span>EN / TH</span></a>
@@ -278,7 +296,6 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
   </div>
 </footer>
 
-<button class="zap-float" onclick="openZapModal()" aria-label="Support the film">⚡</button>
 <button class="back-to-top" id="backToTop" onclick="window.scrollTo({top:0,behavior:'smooth'})" aria-label="Back to top">↑</button>
 
 <script>
@@ -332,28 +349,15 @@ function copyZap() {
     document.getElementById('copySuccess').style.display = 'block';
   });
 }
-
-// Lightbox
-function openLightbox(src) {
-  var img = document.getElementById('lightboxImg');
-  var overlay = document.getElementById('lightboxOverlay');
-  img.src = src;
-  overlay.classList.add('active');
-}
-function closeLightbox(e) {
-  if (e && e.target !== document.getElementById('lightboxOverlay') && e.target !== document.querySelector('.lightbox-close')) return;
-  document.getElementById('lightboxOverlay').classList.remove('active');
-  document.getElementById('lightboxImg').src = '';
+function copySupportAddr() {
+  const address = document.getElementById('spAddressTxt').innerText;
+  navigator.clipboard.writeText(address).then(() => {
+    document.getElementById('spCopied').style.display = 'block';
+  });
 }
 
 // Escape key
-document.addEventListener('keydown', (e) => {
-  if (e.key === 'Escape') {
-    closeZapModal();
-    document.getElementById('lightboxOverlay').classList.remove('active');
-    document.getElementById('lightboxImg').src = '';
-  }
-});
+document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeZapModal(); });
 
 // Mobile Nav
 function toggleMobileNav() {
@@ -392,46 +396,6 @@ const revealObserver = new IntersectionObserver((entries) => {
   entries.forEach(entry => { if (entry.isIntersecting) entry.target.classList.add('visible'); });
 }, { threshold: 0.1, rootMargin: '0px 0px -40px 0px' });
 reveals.forEach(el => revealObserver.observe(el));
-
-// Pre-prod Banner
-(function() {
-  var banner = document.getElementById('preProdBanner');
-  if (!banner) return;
-  try { if (localStorage.getItem('satoshi_preprod_banner_dismissed') === '1') { banner.style.display = 'none'; return; } } catch(e) {}
-  function adjustNav() {
-    var nav = document.querySelector('nav');
-    if (nav && window.getComputedStyle(nav).position === 'fixed') {
-      nav.style.top = banner.offsetHeight + 'px';
-      nav.style.transition = 'top 0.3s ease-out';
-    }
-  }
-  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', adjustNav);
-  else adjustNav();
-})();
-function dismissPreProdBanner() {
-  var banner = document.getElementById('preProdBanner');
-  if (!banner) return;
-  banner.classList.add('dismissed');
-  try { localStorage.setItem('satoshi_preprod_banner_dismissed', '1'); } catch(e) {}
-  setTimeout(function() {
-    banner.style.display = 'none';
-    var nav = document.querySelector('nav');
-    if (nav && window.getComputedStyle(nav).position === 'fixed') nav.style.top = '0';
-  }, 300);
-}
-
-// Block Height Counter
-(function() {
-  var el = document.getElementById('posterBlockHeight');
-  if (!el) return;
-  fetch('https://mempool.space/api/blocks/tip/height')
-    .then(function(r) { return r.text(); })
-    .then(function(height) {
-      var n = parseInt(height, 10);
-      if (!isNaN(n)) el.textContent = n.toLocaleString();
-    })
-    .catch(function() {});
-})();
 </script>
 
 </body>

--- a/verifier.html
+++ b/verifier.html
@@ -139,8 +139,8 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
 <div id="preProdBanner" class="preprod-banner">
   <div class="preprod-content">
     <span class="preprod-text">
-      <span>เว็บไซต์และภาพยนตร์อยู่ในช่วง pre-production · ขออภัยด้วยหาก feature บางส่วนยังไม่ทำงาน</span>
-      <span>Website and film are in pre-production · Apologies if some features don't work yet</span>
+      <span>ฉายแล้วที่ Bitcoin FilmFest 2026 วอร์ซอ — กำลังระดมทุนสร้างฉบับเต็ม · ขออภัยหาก feature บางส่วนยังไม่ทำงาน</span>
+      <span>Screened at Bitcoin FilmFest 2026, Warsaw — now raising the full feature · Apologies if some features don't work yet</span>
     </span>
     <button class="preprod-close" onclick="dismissPreProdBanner()" aria-label="Close banner">×</button>
   </div>

--- a/verifier.html
+++ b/verifier.html
@@ -139,8 +139,8 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
 <div id="preProdBanner" class="preprod-banner">
   <div class="preprod-content">
     <span class="preprod-text">
-      <span>ฉายแล้วที่ Bitcoin FilmFest 2026 วอร์ซอ — กำลังระดมทุนสร้างฉบับเต็ม · ขออภัยหาก feature บางส่วนยังไม่ทำงาน</span>
-      <span>Screened at Bitcoin FilmFest 2026, Warsaw — now raising the full feature · Apologies if some features don't work yet</span>
+      <span>Teaser ฉายแล้วที่ Bitcoin FilmFest 2026 วอร์ซอ — กำลังระดมทุนสร้างฉบับเต็ม · ขออภัยหาก feature บางส่วนยังไม่ทำงาน</span>
+      <span>Teaser screened at Bitcoin FilmFest 2026, Warsaw — now raising the full feature · Apologies if some features don't work yet</span>
     </span>
     <button class="preprod-close" onclick="dismissPreProdBanner()" aria-label="Close banner">×</button>
   </div>


### PR DESCRIPTION
- Hero: Official Selection laurel (Bitcoin FilmFest 2026, Warsaw) as inline SVG
  + standalone assets/laurel-bff26.svg for press use
- #bff section: 'submitted' → Official Selection, with Screenings entry
  ('Changing minds with fiction' block, June 2026) and source link
- New support.html: feature funding — Lightning zap channel + investor/sponsor
  contact, honest-tone bilingual copy (EN default, TH toggle)
- New press.html: logline, broad synopsis (Truth → Past → Present → Future
  timeline only — screenplay in rewrite), teaser embed, key art, festival
  credit, downloads, contact
- Timeline section: replaces 'Three Worlds' framing; WORLD A/B/C labels
  removed, 4 phases, world-c easter-egg hook preserved
- Meta/OG/Twitter tags on index + new pages for Nostr/social sharing
- Pre-production banner across all pages → festival credit + feature raise
- Nav/footer links to Support and Press Kit; README + CLAUDE.md routes updated

https://claude.ai/code/session_01J8G12dh9XyjbdczCw7i6pJ