### PR TITLE
Remove SATOSHI.MEDIA (photobook) nav link, replaced by PRESS

### DIFF
--- a/forum.html
+++ b/forum.html
@@ -210,7 +210,7 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
   <a href="index.html" class="nav-logo">SATOSHi <span class="nav-page-label">FORUM</span></a>
   <div class="nav-menu" id="navMenu">
     <a href="index.html" class="nav-link"><span class="th-only">หน้าหลัก</span><span class="en-only">HOME</span></a>
-    <a href="photobook.html" class="nav-link"><span class="th-only">หนัง / สื่อ / ภาพ</span><span class="en-only">SATOSHI.MEDIA</span></a>
+    <a href="press.html" class="nav-link"><span class="th-only">ข้อมูลสื่อ — PRESS</span><span class="en-only">PRESS KIT</span></a>
     <a href="https://app.gitbook.com/invite/CC1p6uOmzX05YyLDPevJ/r3fCPzAmLSaX2XHCIdgr" target="_blank" class="nav-link th-only">ร่วมพัฒนาบทภาพยนตร์และสารคดี</a>
     <a href="https://app.gitbook.com/invite/CC1p6uOmzX05YyLDPevJ/r3fCPzAmLSaX2XHCIdgr" target="_blank" class="nav-link en-only">SCRIPT & DOC COLLAB</a>
     <a href="https://github.com/sootisooti/satoshi.film" target="_blank" class="nav-link th-only">ร่วมพัฒนาเว็ปไซต์ SATOSHi</a>

--- a/index.html
+++ b/index.html
@@ -751,7 +751,6 @@ function dismissPreProdBanner() {
   <a href="#" class="nav-logo">SATOSHi</a>
   <div class="nav-menu" id="navMenu">
     <a href="#" class="nav-link" onclick="openTeaser();return false;" style="color:#F7931A;border-bottom:1px solid rgba(247,147,26,0.4);padding-bottom:1px;">TEASER</a>
-    <a href="photobook.html" class="nav-link"><span class="th-only">หนัง / สื่อ / ภาพ</span><span class="en-only">SATOSHI.MEDIA</span></a>
     <a href="support.html" class="nav-link"><span class="th-only">สนับสนุนฉบับเต็ม</span><span class="en-only">SUPPORT</span></a>
     <a href="press.html" class="nav-link"><span class="th-only">ข้อมูลสื่อ — PRESS</span><span class="en-only">PRESS KIT</span></a>
     <a href="https://app.gitbook.com/invite/CC1p6uOmzX05YyLDPevJ/r3fCPzAmLSaX2XHCIdgr" target="_blank" class="nav-link th-only">ร่วมพัฒนาบทภาพยนตร์และสารคดี</a>

--- a/press.html
+++ b/press.html
@@ -170,7 +170,6 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
   <div class="nav-menu" id="navMenu">
     <a href="index.html" class="nav-link"><span class="th-only">หน้าหลัก</span><span class="en-only">HOME</span></a>
     <a href="support.html" class="nav-link"><span class="th-only">สนับสนุนฉบับเต็ม</span><span class="en-only">SUPPORT</span></a>
-    <a href="photobook.html" class="nav-link"><span class="th-only">หนัง / สื่อ / ภาพ</span><span class="en-only">SATOSHI.MEDIA</span></a>
     <a href="https://github.com/sootisooti/satoshi.film" target="_blank" class="nav-link th-only">ร่วมพัฒนาเว็ปไซต์ SATOSHi</a>
     <a href="https://github.com/sootisooti/satoshi.film" target="_blank" class="nav-link en-only">WEBSITE COLLAB</a>
   </div>

--- a/support.html
+++ b/support.html
@@ -193,7 +193,6 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
   <div class="nav-menu" id="navMenu">
     <a href="index.html" class="nav-link"><span class="th-only">หน้าหลัก</span><span class="en-only">HOME</span></a>
     <a href="press.html" class="nav-link"><span class="th-only">ข้อมูลสื่อ — PRESS</span><span class="en-only">PRESS KIT</span></a>
-    <a href="photobook.html" class="nav-link"><span class="th-only">หนัง / สื่อ / ภาพ</span><span class="en-only">SATOSHI.MEDIA</span></a>
     <a href="https://github.com/sootisooti/satoshi.film" target="_blank" class="nav-link th-only">ร่วมพัฒนาเว็ปไซต์ SATOSHi</a>
     <a href="https://github.com/sootisooti/satoshi.film" target="_blank" class="nav-link en-only">WEBSITE COLLAB</a>
     <div class="nav-mobile-divider mobile-only"></div>

--- a/verifier.html
+++ b/verifier.html
@@ -182,7 +182,7 @@ footer { padding: 60px 40px 40px; border-top: 1px solid rgba(255,255,255,0.06); 
   <a href="index.html" class="nav-logo">SATOSHi <span class="nav-page-label">SEED</span></a>
   <div class="nav-menu" id="navMenu">
     <a href="index.html" class="nav-link"><span class="th-only">หน้าหลัก</span><span class="en-only">HOME</span></a>
-    <a href="photobook.html" class="nav-link"><span class="th-only">หนัง / สื่อ / ภาพ</span><span class="en-only">SATOSHI.MEDIA</span></a>
+    <a href="press.html" class="nav-link"><span class="th-only">ข้อมูลสื่อ — PRESS</span><span class="en-only">PRESS KIT</span></a>
     <a href="https://app.gitbook.com/invite/CC1p6uOmzX05YyLDPevJ/r3fCPzAmLSaX2XHCIdgr" target="_blank" class="nav-link th-only">ร่วมพัฒนาบทภาพยนตร์และสารคดี</a>
     <a href="https://app.gitbook.com/invite/CC1p6uOmzX05YyLDPevJ/r3fCPzAmLSaX2XHCIdgr" target="_blank" class="nav-link en-only">SCRIPT & DOC COLLAB</a>
     <a href="https://github.com/sootisooti/satoshi.film" target="_blank" class="nav-link th-only">ร่วมพัฒนาเว็ปไซต์ SATOSHi</a>


### PR DESCRIPTION
Press kit page supersedes the media/photobook nav entry. On verifier
and forum navs, which had no press link, the slot is replaced with the
PRESS KIT link. photobook.html itself remains reachable by direct URL.

https://claude.ai/code/session_01UvJc55JzYASsmgnGjRxHke