### PR TITLE
Remove duplicate section header titles from cypherpunk section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1078,8 +1078,6 @@ function dismissPreProdBanner() {
 <section class="cypherpunk" id="cypherpunk">
   <div class="section-header">
     <div class="section-header-label"><span class="th-only">WE ARE ALL SATOSHI — เราทุกคนคือซาโตชิ</span><span class="en-only">WE ARE ALL SATOSHI — เราทุกคนคือซาโตชิ</span></div>
-    <div class="section-header-title th-only">ผู้ใดมี satoshi — ผู้นั้นคือ Satoshi</div>
-    <div class="section-header-title en-only">Whoever holds satoshi — is Satoshi.</div>
   </div>
 
   <div class="ch-group reveal">


### PR DESCRIPTION
## Summary
Removed redundant section header title elements from the cypherpunk section that duplicated the main section header label.

## Changes
- Removed Thai language section header title: `ผู้ใดมี satoshi — ผู้นั้นคือ Satoshi`
- Removed English language section header title: `Whoever holds satoshi — is Satoshi.`

## Details
The cypherpunk section (`#cypherpunk`) had both a `section-header-label` and duplicate `section-header-title` elements that conveyed the same message in both languages. The section header label already displays "WE ARE ALL SATOSHI — เราทุกคนคือซาโตชิ" in both Thai and English, making the additional title elements redundant. This cleanup simplifies the DOM structure while maintaining the intended bilingual messaging.

https://claude.ai/code/session_01LYEcLCoRjyeMWBtifxErnc