### PR TITLE
Anti-rerun curation, W18 reconstruction, and archive date repair

### DIFF
--- a/forum-archive/2026-W17.json
+++ b/forum-archive/2026-W17.json
@@ -1,5 +1,5 @@
 {
-  "curated_date": "2025-04-27",
+  "curated_date": "2026-04-20",
   "block_height": "-",
   "curator_note_th": "สัปดาห์นี้เราเห็นคำถามที่ว่า หากไม่มีกำไร คุณจะยังอยู่กับบิตคอยน์ไหม — คำถามที่ตรงไปที่แก่นของความหมาย",
   "curator_note_en": "This week we see the question asked plainly: without profit, would you remain — a question that cuts to the meaning itself.",

--- a/forum-archive/2026-W18.json
+++ b/forum-archive/2026-W18.json
@@ -1,0 +1,47 @@
+{
+  "curated_date": "2026-04-27",
+  "block_height": "-",
+  "reconstruction": true,
+  "reconstructed_date": "2026-06-13",
+  "curator_note_th": "สัปดาห์ของวันที่ 27 เมษายน เครื่องบันทึกของเราล้มเงียบไป รอบรันต้นฉบับพังกลางทางโดยไม่เหลืออะไรไว้เลย สิ่งที่อยู่ตรงหน้าคือการประกอบขึ้นใหม่จากกระทู้สามเส้นที่ยืนยันได้ว่ายังมีชีวิตอยู่ทั้งสองฝั่งของสัปดาห์ที่หายไป ที่เหลือสูญไปกับเครื่อง — ความจริงรอการตรวจสอบ และจดหมายเหตุก็เช่นกัน",
+  "curator_note_en": "The week of April 27, our recording machine fell silent — the original run crashed and saved nothing. What you see here is a reconstruction: the three threads we can verify were alive on both shores of the missing week. The rest is gone with the machine. Truth waits to be verified, and so do archives.",
+  "topics": [
+    {
+      "bitcointalk_topic_id": "5580736",
+      "title_en": "You Are the Asset They Buy and Sell",
+      "title_th": "คุณนั่นแหละคือสินทรัพย์ที่เขาซื้อขายกัน",
+      "author": "Churchillvv",
+      "board": "Bitcoin Discussion",
+      "summary_en": "The thread argues that ordinary people — their attention, data, and labor — are the real underlying asset traded by platforms and financial systems, priced without their consent.",
+      "summary_th": "ความสนใจ ข้อมูล และหยาดเหงื่อของคนธรรมดา คือสินทรัพย์ตัวจริงที่แพลตฟอร์มและระบบการเงินหยิบไปซื้อขาย โดยที่เจ้าตัวไม่เคยได้ร่วมตั้งราคา",
+      "take_en": "Four generations of one family have each been an entry in someone else's ledger; the first step out of the book is noticing you are written in it.",
+      "take_th": "สี่รุ่นของครอบครัวหนึ่งล้วนเคยเป็นรายการในสมุดบัญชีของใครบางคน ก้าวแรกของการเดินออกจากสมุดเล่มนั้นคือการรู้ตัวว่าชื่อเราถูกจดอยู่ข้างใน",
+      "source_url": "https://bitcointalk.org/index.php?topic=5580736.0"
+    },
+    {
+      "bitcointalk_topic_id": "5580401",
+      "title_en": "Avoiding an Unnecessary Quantum Freeze",
+      "title_th": "เลี่ยงการแช่แข็งเหรียญโดยไม่จำเป็นในยุค quantum",
+      "author": "tromp",
+      "board": "Development & Technical Discussion",
+      "summary_en": "An ongoing debate over whether pre-emptively freezing coins on legacy addresses to defend against quantum attacks protects the system or betrays its first principle of ownership.",
+      "summary_th": "ข้อถกเถียงที่ยังเดินต่อเนื่อง ว่าการชิงแช่แข็งเหรียญใน address รุ่นเก่าเพื่อกันภัย quantum คือการปกป้องระบบ หรือคือการหักหลังหลักกรรมสิทธิ์ข้อแรกของมันเอง",
+      "take_en": "Every inheritance carries the same question: protect what was left to us by locking it away, or honor it by leaving the key where the next hand can reach.",
+      "take_th": "มรดกทุกชิ้นพ่วงคำถามเดียวกันมาเสมอ จะปกป้องสิ่งที่ตกทอดมาด้วยการล็อกเก็บ หรือให้เกียรติมันด้วยการวางกุญแจไว้ให้มือของรุ่นถัดไปเอื้อมถึง",
+      "source_url": "https://bitcointalk.org/index.php?topic=5580401.0"
+    },
+    {
+      "bitcointalk_topic_id": "5550298",
+      "title_en": "J. Lopp's Post-Quantum Migration BIP",
+      "title_th": "BIP ของ J. Lopp ว่าด้วยการอัปเกรดสู่ post-quantum",
+      "author": "Pmalek",
+      "board": "Development & Technical Discussion",
+      "summary_en": "A formal proposal mapping how Bitcoin could move its cryptography beyond the reach of quantum computers before the threat actually arrives.",
+      "summary_th": "ข้อเสนออย่างเป็นทางการที่วางเส้นทางพา cryptography ของ Bitcoin ออกไปให้พ้นมือ quantum computer ก่อนภัยนั้นจะมาถึงจริง",
+      "take_en": "Preparing for a storm no one alive has ever seen is either paranoia or parenthood — the protocol's builders have already chosen which one.",
+      "take_th": "การเตรียมรับพายุที่ยังไม่มีใครเคยเห็นด้วยตา จะเรียกว่าความหวาดระแวงหรือความเป็นพ่อแม่ก็ได้ — ผู้สร้าง protocol เลือกคำตอบของตัวเองไปแล้ว",
+      "source_url": "https://bitcointalk.org/index.php?topic=5550298.0"
+    }
+  ],
+  "iso_week": "2026-W18"
+}

--- a/forum-archive/2026-W19.json
+++ b/forum-archive/2026-W19.json
@@ -1,5 +1,5 @@
 {
-  "curated_date": "2025-01-30",
+  "curated_date": "2026-05-04",
   "block_height": "-",
   "curator_note_en": "This week's threads circle the film's central question: who built the cage, who holds the key, and whether the next generation will finally learn to verify before they trust.",
   "curator_note_th": "เนื้อหาสัปดาห์นี้วนรอบคำถามหลักของภาพยนตร์ ใครสร้างกรง ใครถือกุญแจ และคนรุ่นต่อไปจะเรียนรู้ที่จะพิสูจน์ก่อนเชื่อได้หรือไม่",

--- a/forum-archive/2026-W20.json
+++ b/forum-archive/2026-W20.json
@@ -1,5 +1,5 @@
 {
-  "curated_date": "2025-07-11",
+  "curated_date": "2026-05-11",
   "block_height": "-",
   "curator_note_en": "This week's threads trace the invisible architecture of trust — from cryptographic primitives forged in the early internet to the quiet anxiety of a system that may one day need to shed its own skin.",
   "curator_note_th": "ชุดบทความสัปดาห์นี้สืบรอยสถาปัตยกรรมแห่งความเชื่อใจที่มองไม่เห็น ตั้งแต่รากฐาน cryptography ในยุคอินเทอร์เน็ตแรกเริ่ม ไปจนถึงความกังวลเงียบๆ ของระบบที่อาจต้องลอกคราบตัวเองในวันหนึ่ง",

--- a/forum-archive/2026-W21.json
+++ b/forum-archive/2026-W21.json
@@ -1,5 +1,5 @@
 {
-  "curated_date": "2025-07-10",
+  "curated_date": "2026-05-18",
   "block_height": "-",
   "curator_note_en": "This week's threads trace the quiet architecture of trust — from cypherpunk origins to the question of who inherits the cost when systems fail.",
   "curator_note_th": "หัวข้อสัปดาห์นี้สะท้อนโครงสร้างความเชื่อใจที่ถูกสร้างอย่างเงียบงัน ตั้งแต่รากฐานของ cypherpunk จนถึงคำถามว่าใครคือผู้แบกรับต้นทุนเมื่อระบบล้มเหลว",

--- a/forum-archive/2026-W22.json
+++ b/forum-archive/2026-W22.json
@@ -1,5 +1,5 @@
 {
-  "curated_date": "2025-05-22",
+  "curated_date": "2026-05-25",
   "block_height": "-",
   "curator_note_en": "This week's threads trace the quiet tension between systems built to endure and people left to absorb their failures — the same tension that runs through every generation in the film.",
   "curator_note_th": "หัวข้อสัปดาห์นี้สะท้อนความตึงเครียดที่ซ่อนอยู่ระหว่างระบบที่ถูกสร้างมาให้ยืนยาว กับผู้คนที่ถูกทิ้งให้แบกรับความล้มเหลวของมันแทน — ความตึงเครียดเดียวกับที่흐ลั่งผ่านทุกรุ่นในภาพยนตร์",

--- a/forum-archive/2026-W23.json
+++ b/forum-archive/2026-W23.json
@@ -1,5 +1,5 @@
 {
-  "curated_date": "2026-06-07",
+  "curated_date": "2026-06-01",
   "block_height": "-",
   "curator_note_en": "This week's threads circle a quiet but urgent question: who built the cage, who holds the key, and whether the next generation will know the difference.",
   "curator_note_th": "สัปดาห์นี้ กระทู้ที่คัดสรรต่างวนเวียนอยู่กับคำถามเงียบๆ แต่เร่งด่วน ว่าใครสร้างกรง ใครถือกุญแจ และคนรุ่นต่อไปจะรู้ความต่างนั้นหรือไม่",

--- a/forum-archive/index.json
+++ b/forum-archive/index.json
@@ -2,32 +2,37 @@
   "weeks": [
     {
       "iso_week": "2026-W23",
-      "curated_date": "2026-06-07",
+      "curated_date": "2026-06-01",
       "topic_count": 21
     },
     {
       "iso_week": "2026-W22",
-      "curated_date": "2025-05-22",
+      "curated_date": "2026-05-25",
       "topic_count": 21
     },
     {
       "iso_week": "2026-W21",
-      "curated_date": "2025-07-10",
+      "curated_date": "2026-05-18",
       "topic_count": 21
     },
     {
       "iso_week": "2026-W20",
-      "curated_date": "2025-07-11",
+      "curated_date": "2026-05-11",
       "topic_count": 21
     },
     {
       "iso_week": "2026-W19",
-      "curated_date": "2025-01-30",
+      "curated_date": "2026-05-04",
       "topic_count": 21
     },
     {
+      "iso_week": "2026-W18",
+      "curated_date": "2026-04-27",
+      "topic_count": 3
+    },
+    {
       "iso_week": "2026-W17",
-      "curated_date": "2025-04-27",
+      "curated_date": "2026-04-20",
       "topic_count": 21
     }
   ]

--- a/forum.html
+++ b/forum.html
@@ -466,11 +466,20 @@ function dismissPreProdBanner() {
     countEl.textContent = data.topics.length;
 
     const topics = data.topics.slice(0, 21);
-    grid.innerHTML = topics.map((topic, index) => {
+    const total = String(topics.length).padStart(2, '0');
+    const noteTh = data.curator_note_th || '';
+    const noteEn = data.curator_note_en || '';
+    const noteHtml = (noteTh || noteEn) ? `
+        <div class="forum-card forum-curator-note" style="grid-column: 1 / -1;">
+          <div class="forum-card-take-label"><span class="th-only">บันทึกผู้คัดสรร</span><span class="en-only">CURATOR'S NOTE</span></div>
+          <div class="forum-card-take-th th-only" style="font-style: italic;">${escapeHtml(noteTh)}</div>
+          <div class="forum-card-take-en en-only" style="font-style: italic;">${escapeHtml(noteEn)}</div>
+        </div>` : '';
+    grid.innerHTML = noteHtml + topics.map((topic, index) => {
       const num = String(index + 1).padStart(2, '0');
       return `
         <div class="forum-card reveal" id="forum-topic-${num}">
-          <div class="forum-card-num">TOPIC ${num} / 21</div>
+          <div class="forum-card-num">TOPIC ${num} / ${total}</div>
           <div class="forum-card-title-th th-only">${escapeHtml(topic.title_th || '')}</div>
           <div class="forum-card-title-en en-only">${escapeHtml(topic.title_en || '')}</div>
           <div class="forum-card-summary-th th-only">${escapeHtml(topic.summary_th || '')}</div>

--- a/scripts/curate-forum.js
+++ b/scripts/curate-forum.js
@@ -38,7 +38,10 @@ const BOARDS = [
   { id: 75, name: "Politics & Society" },
 ];
 
-const MAX_CANDIDATES = 60;
+const PAGES_PER_BOARD = 2; // board index pages to scrape, 40 threads each
+const MAX_CANDIDATES = 120;
+const COOLDOWN_SOFT_WEEKS = 4; // featured threads stay on the avoid-rerun list this long
+const MIN_POOL_AFTER_FILTER = 30; // relax the hard filter below this many candidates
 const OUT_FILE = "forum-daily.json";
 const MODEL = "claude-opus-4-8";
 const MAX_TOKENS = 16000;
@@ -119,9 +122,9 @@ function parseBoardHtml(html, boardName) {
   });
 }
 
-async function fetchBoard(board) {
-  const url = `https://bitcointalk.org/index.php?board=${board.id}.0`;
-  log(`Fetching board ${board.id} (${board.name})`);
+async function fetchBoardPage(board, offset) {
+  const url = `https://bitcointalk.org/index.php?board=${board.id}.${offset}`;
+  log(`Fetching board ${board.id} (${board.name}) offset ${offset}`);
 
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
@@ -155,6 +158,16 @@ async function fetchBoard(board) {
   }
 }
 
+async function fetchBoard(board) {
+  // Pages fetched sequentially per board (polite to the server);
+  // boards themselves still run in parallel.
+  const pages = [];
+  for (let p = 0; p < PAGES_PER_BOARD; p++) {
+    pages.push(await fetchBoardPage(board, p * 40));
+  }
+  return pages.flat();
+}
+
 function dedupeByTopicId(items) {
   const seen = new Set();
   return items.filter((it) => {
@@ -164,9 +177,61 @@ function dedupeByTopicId(items) {
   });
 }
 
-function buildPrompt(candidates) {
+/**
+ * Threads featured in recent digests. Last week's ids get hard-excluded
+ * from the candidate pool; older recent weeks become a soft avoid-rerun
+ * list inside the prompt (Claude may bring back at most 2, with a reason).
+ */
+async function loadRecentlyFeatured() {
+  const readJson = async (path) => {
+    try {
+      return JSON.parse(await readFile(path, "utf-8"));
+    } catch {
+      return null;
+    }
+  };
+
+  const hardIds = new Set();
+  const daily = await readJson(resolve(repoRoot, OUT_FILE));
+  if (daily?.topics) {
+    for (const t of daily.topics) {
+      if (t.bitcointalk_topic_id) hardIds.add(String(t.bitcointalk_topic_id));
+    }
+    log(`Cooldown: ${hardIds.size} topics from last week (${daily.iso_week || "?"}) hard-excluded`);
+  } else {
+    log("Cooldown: no previous forum-daily.json found, nothing hard-excluded");
+  }
+
+  const soft = new Map(); // topic_id -> { title, weeks }
+  const manifest = await readJson(resolve(archiveDir, "index.json"));
+  const recentWeeks = (manifest?.weeks || [])
+    .map((w) => w.iso_week)
+    .sort()
+    .reverse()
+    .slice(0, COOLDOWN_SOFT_WEEKS - 1);
+
+  for (const wk of recentWeeks) {
+    const data = await readJson(resolve(archiveDir, `${wk}.json`));
+    for (const t of data?.topics || []) {
+      const id = String(t.bitcointalk_topic_id || "");
+      if (!id || hardIds.has(id)) continue;
+      const entry = soft.get(id) || { title: t.title_en || "", weeks: [] };
+      entry.weeks.push(wk);
+      soft.set(id, entry);
+    }
+  }
+  log(`Cooldown: ${soft.size} topics from [${recentWeeks.join(", ")}] on the soft avoid-list`);
+
+  return { hardIds, soft };
+}
+
+function buildPrompt(candidates, recentlyFeatured) {
   const candidateLines = candidates
     .map((c) => `${c.title} | ${c.url} | ${c.author} | ${c.board}`)
+    .join("\n");
+
+  const softLines = [...recentlyFeatured.soft.entries()]
+    .map(([id, e]) => `${id} | ${e.title} | featured: ${e.weeks.join(", ")}`)
     .join("\n");
 
   return `You are the editorial curator for SATOSHI.FILM - a Thai feature film about
@@ -183,11 +248,22 @@ Select up to 21 that resonate with the film's themes:
 - The cypherpunk lineage (Chaum, Hughes, Szabo, Finney, Sassaman, May, Back)
 - Quiet craftsmanship over spectacle
 - Thai / Southeast Asian perspectives if present
+- Freshness: prefer threads this digest has never featured before
 
 AVOID:
 - Price speculation threads, shitcoin pumps, trading tips
 - Threads that are mostly noise, drama, or scam accusations
 - Threads in languages other than English (unless specifically Thai)
+
+RECENTLY FEATURED — anti-rerun rules:
+Threads featured LAST week have already been removed from your candidate
+list. The threads below appeared in earlier recent digests; the reader has
+seen them. Default to NOT selecting them again. You may bring back AT MOST
+2 of them, and only when the thread has a genuinely new development since
+it was featured — and when you do, the take must acknowledge that the
+story has moved.
+
+${softLines || "(none this run)"}
 
 If fewer than 21 strong candidates exist, pick the best available and note
 this in the curator_note. Never invent threads - only use ones from the list.
@@ -356,9 +432,20 @@ async function callClaude(prompt) {
       process.exit(2);
     }
 
+    const recentlyFeatured = await loadRecentlyFeatured();
+    const fresh = candidates.filter(
+      (c) => !recentlyFeatured.hardIds.has(String(c.topic_id))
+    );
+    if (fresh.length >= MIN_POOL_AFTER_FILTER) {
+      log(`Hard filter: ${candidates.length} -> ${fresh.length} candidates after removing last week's topics`);
+      candidates = fresh;
+    } else {
+      log(`Hard filter RELAXED: only ${fresh.length} fresh candidates (<${MIN_POOL_AFTER_FILTER}), keeping repeats this run`);
+    }
+
     candidates = candidates.slice(0, MAX_CANDIDATES);
 
-    const prompt = buildPrompt(candidates);
+    const prompt = buildPrompt(candidates, recentlyFeatured);
     const raw = await callClaude(prompt);
 
     let parsed;

--- a/scripts/test-regression.mjs
+++ b/scripts/test-regression.mjs
@@ -12,6 +12,12 @@ const src = await readFile(new URL("./curate-forum.js", import.meta.url), "utf-8
 const checks = [
   ["Model is claude-opus-4-8",          /claude-opus-4-8/.test(src)],
   ["Adaptive thinking enabled",          /thinking:\s*\{\s*type:\s*"adaptive"\s*\}/.test(src)],
+  ["RECENTLY FEATURED anti-rerun rules", /RECENTLY FEATURED/.test(src)],
+  ["Freshness criterion in prompt",      /Freshness: prefer threads/.test(src)],
+  ["Hard cooldown filter (hardIds)",     /hardIds/.test(src)],
+  ["Soft cooldown window const",         /COOLDOWN_SOFT_WEEKS/.test(src)],
+  ["Two pages scraped per board",        /PAGES_PER_BOARD = 2/.test(src)],
+  ["Filter safety valve present",        /MIN_POOL_AFTER_FILTER/.test(src)],
   ["extractJson function present",       /function extractJson/.test(src)],
   ["Raw response debug log present",     /\[DEBUG\] Raw response/.test(src)],
   ["System prompt field present",        /system:.*JSON-only API endpoint/.test(src)],


### PR DESCRIPTION
## Why

Consecutive digests had converged into reshuffled reruns — W23→W24 overlap reached **11/21 topics**, and 27% of all slots across 7 weeks were repeats. Root causes: the scraper only saw page 1 of each board (slow-moving), the curator had no memory of past weeks, and the editorial criteria had no freshness pressure. Separately, W18 has been missing from the archive since its run crashed on 2026-04-27.

## 1. Anti-rerun curation (`scripts/curate-forum.js`)

- **Hard cooldown** — last week's topic IDs are read from `forum-daily.json` and removed from the candidate pool *before* the prompt (deterministic, not reliant on model obedience). Safety valve: if fewer than 30 fresh candidates remain, the filter relaxes for that run with a log line.
- **Soft cooldown** — topics from the 3 weeks before that (read from the archive) go into a `RECENTLY FEATURED` prompt section: default to not re-selecting; at most 2 may return, only on a genuinely new development, and the take must acknowledge the story moved.
- **Deeper pool** — scrape 2 index pages per board (40 → 80 threads each, ~160 → ~320 candidates), `MAX_CANDIDATES` 60 → 120, plus a new "Freshness" criterion in the editorial list.

## 2. W18 reconstruction (`forum-archive/2026-W18.json`)

The 2026-04-27 scheduled run crashed parsing the model response (pre-#27/#28 fixes) and saved nothing — the real W18 digest is unrecoverable. Rather than fabricate a full week, W18 now exists as an **honest, labeled reconstruction** (`"reconstruction": true`): the 3 threads verifiably alive on both shores of the gap (featured in both W17 and W19 — *You Are the Asset They Buy and Sell*, *Avoiding an Unnecessary Quantum Freeze*, *J. Lopp's Post-Quantum Migration BIP*), with fresh summaries/takes in the new Thai standard and a curator note that tells the story of the silent week. On-theme: truth waits to be verified, and so do archives.

## 3. Archive metadata repair

`curated_date` in the W17/W19–W23 files and the manifest carried impossible 2025 dates from the pre-June-7 bug era (these display in the UI when a week is selected). Corrected to actual run dates from the workflow history; W23 now shows its run date (06-01) instead of the repair date (06-07).

## 4. `forum.html` (two surgical changes)

- Render `curator_note_th/en` above the grid — the field existed in every digest but was never displayed; W18's framing depends on it and every other week gains its weekly note.
- `TOPIC nn / 21` hardcode → real topic count, so W18's 3-fragment week renders honestly.

## Validation

- `node --check` clean; regression suite extended with 6 new checks — **37/37 passing**
- All 7 archive files + manifest re-parsed as valid JSON; Cyrillic/Greek glyph scan over every Thai field clean
- BUNDLES object, Verify modal, custom cursor, easter eggs untouched (forum.html edit is scoped to `renderForumCards`)

Note: independent of #77 (no overlapping hunks — #77 changes title lines in the same archive files; this PR changes only their `curated_date` lines and adds W18). Merge in either order.

https://claude.ai/code/session_01PnFPtQvA1dTUHnaaYVM3Xo

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnFPtQvA1dTUHnaaYVM3Xo)_